### PR TITLE
build(rollup): config libraries from node_modules as externals

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "printWidth": 120
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,6 @@ import replace from '@rollup/plugin-replace';
 import typescript from '@rollup/plugin-typescript';
 
 const extensions = ['.ts', '.tsx'];
-const EXTERNALS = ['react'];
 
 export default {
   input: 'src/index.tsx',
@@ -23,12 +22,11 @@ export default {
     }),
     resolve({
       extensions,
-      skip: EXTERNALS,
     }),
     typescript({
       tsconfig: 'tsconfig.build.json',
     }),
     commonjs(),
   ],
-  external: EXTERNALS,
+  external: [/node_modules/],
 };


### PR DESCRIPTION
- configure all dependencies from node_modules as externals in rollup config

https://github.com/landbot-org/lui/compare/rollup-externals?expand=1

Test in box-component branch

Before:

![Screenshot 2022-10-25 at 08 46 26](https://user-images.githubusercontent.com/19800652/197703132-b563f67d-a270-4e05-b8ef-37e66146eea7.png)

After:

![Screenshot 2022-10-25 at 08 46 49](https://user-images.githubusercontent.com/19800652/197703169-95a92d32-dc6c-4e4d-b8a6-02ed785db33f.png)
