### PR TITLE
fix: types extend base spacing

### DIFF
--- a/src/Box/types.ts
+++ b/src/Box/types.ts
@@ -1,29 +1,12 @@
 import { BaseSpacingProps } from '../BaseSpacing';
 
-type FlexAlignType =
-  | 'stretch'
-  | 'flex-start'
-  | 'flex-end'
-  | 'center'
-  | 'baseline';
+type FlexAlignType = 'stretch' | 'flex-start' | 'flex-end' | 'center' | 'baseline';
 type FlexDirectionType = 'row' | 'column';
-type FlexJustifyType =
-  | 'flex-start'
-  | 'flex-end'
-  | 'center'
-  | 'space-between'
-  | 'space-around'
-  | 'space-evenly';
+type FlexJustifyType = 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'space-evenly';
 type FlexWrapType = 'nowrap' | 'wrap' | 'wrap-reverse';
-type DisplayType =
-  | 'block'
-  | 'flex'
-  | 'inline'
-  | 'inline-block'
-  | 'inline-flex'
-  | 'none';
+type DisplayType = 'block' | 'flex' | 'inline' | 'inline-block' | 'inline-flex' | 'none';
 
-export interface BoxProps extends BaseSpacingProps {
+export interface BoxProps extends BaseSpacingProps, React.HTMLAttributes<HTMLDivElement> {
   alignItems?: FlexAlignType;
   as?: React.ElementType | keyof JSX.IntrinsicElements;
   children: React.ReactNode;

--- a/src/Typography/types.ts
+++ b/src/Typography/types.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BaseSpacingProps } from '../BaseSpacing';
 
 import { ColorsTypes } from '../shared/theme.types';
 
@@ -18,7 +19,7 @@ export type TypographyVariants =
 
 type FontWeightVariants = 400 | 500 | 700;
 
-export interface TypographyProps {
+export interface TypographyProps extends BaseSpacingProps, React.HTMLAttributes<HTMLParagraphElement> {
   as?: React.ElementType | keyof JSX.IntrinsicElements;
   children: React.ReactNode;
   color?: ColorsTypes;


### PR DESCRIPTION
~According to the rule "Every component extends spacing props"~ As Box and Typography accepts spacing props, types now extend BaseSpacingProps to allow the usage of spacing props.