### PR TITLE
feat(Button): add button component

### DIFF
--- a/.storybook/preview.cjs
+++ b/.storybook/preview.cjs
@@ -1,9 +1,8 @@
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
     matchers: {
-      color: /(background|color)$/i,
       date: /Date$/,
     },
   },
-}
+};

--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -1,30 +1,31 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { userEvent, within } from '@storybook/testing-library';
-import { expect } from '@storybook/jest';
 
-import { Button, ButtonPropTypes } from './Button';
+import { Button } from './Button';
+import { theme } from '../shared/theme';
+import { ThemeProvider } from 'styled-components';
+import { ButtonProps } from './types';
 
 export default {
-  title: 'Example/Button',
+  title: 'Components/Button',
   component: Button,
   argTypes: {
-    backgroundColor: { control: 'color' },
+    children: { control: 'text' },
+    disabled: { control: 'boolean' },
   },
-  parameters: {
-    componentSubtitle: 'Displays an awesome button',
+  args: {
+    children: 'Button',
+    color: 'pink.main',
+    size: 'medium',
+    variant: 'contained',
+    disabled: false,
   },
 } as ComponentMeta<typeof Button>;
 
-const Template: ComponentStory<typeof Button> = (args: ButtonPropTypes) => <Button {...args} />;
+const Template: ComponentStory<typeof Button> = (args: ButtonProps) => (
+  <ThemeProvider theme={theme}>
+    <Button {...args} />
+  </ThemeProvider>
+);
 
-export const Primary = Template.bind({});
-Primary.args = {
-  label: 'Button',
-};
-
-Primary.play = async ({ args, canvasElement }) => {
-  const canvas = within(canvasElement);
-  await userEvent.click(canvas.getByRole('button'));
-  await expect(args.onClick).toHaveBeenCalled();
-};
+export const Default = Template.bind({});

--- a/src/Button/Button.styles.ts
+++ b/src/Button/Button.styles.ts
@@ -1,0 +1,46 @@
+import styled, { css } from 'styled-components';
+import { Typography } from '../Typography';
+import { SIZES_MAPPING } from './constants';
+import { ButtonVariants, ColorTypes, SizeTypes } from './types';
+import { getButtonVariantStyles, getTypographyVariantStyles } from './utils';
+
+interface StyledButtonProps {
+  $color: ColorTypes;
+  $size: SizeTypes;
+  $variant: ButtonVariants;
+  disabled: boolean;
+}
+
+interface StyledTypographyProps {
+  $color: ColorTypes;
+  $variant: ButtonVariants;
+  disabled: boolean;
+  variant: string;
+  as: string;
+}
+
+const BaseButtonStyles = css<StyledButtonProps>`
+  ${({ theme, $color, $variant, disabled }) => getButtonVariantStyles(theme, $color, $variant, disabled)}
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  height: ${({ $size }) => SIZES_MAPPING[$size]};
+  min-width: 80px;
+  padding: 0 16px;
+  &:hover {
+    cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
+  }
+`;
+
+export const StyledLink = styled.a<StyledButtonProps>`
+  ${BaseButtonStyles}
+  text-decoration: none;
+`;
+
+export const StyledButton = styled.button<StyledButtonProps>`
+  ${BaseButtonStyles}
+`;
+
+export const StyledTypography = styled(Typography)<StyledTypographyProps>`
+  ${({ theme, $color, $variant, disabled }) => getTypographyVariantStyles(theme, $color, $variant, disabled)}
+`;

--- a/src/Button/Button.test.tsx
+++ b/src/Button/Button.test.tsx
@@ -4,7 +4,62 @@ import { Button } from './Button';
 
 describe('Button', () => {
   it('renders by default', () => {
-    const { getByText } = render(<Button label="test" />);
-    expect(getByText('test')).toBeInTheDocument();
+    const { getByText } = render(<Button>default</Button>);
+    expect(getByText('default')).toBeInTheDocument();
+  });
+  it('renders contained button', () => {
+    const { getByText } = render(<Button variant="contained">contained</Button>);
+    expect(getByText('contained')).toBeInTheDocument();
+  });
+  it('renders outlined button', () => {
+    const { getByText } = render(<Button variant="outlined">outlined</Button>);
+    expect(getByText('outlined')).toBeInTheDocument();
+  });
+  it('renders text button', () => {
+    const { getByText } = render(<Button variant="text">text</Button>);
+    expect(getByText('text')).toBeInTheDocument();
+  });
+  it('renders small button', () => {
+    const { getByText } = render(<Button size="small">small</Button>);
+    expect(getByText('small')).toBeInTheDocument();
+  });
+  it('renders medium button', () => {
+    const { getByText } = render(<Button size="medium">medium</Button>);
+    expect(getByText('medium')).toBeInTheDocument();
+  });
+  it('renders large button', () => {
+    const { getByText } = render(<Button size="large">large</Button>);
+    expect(getByText('large')).toBeInTheDocument();
+  });
+  it('renders button with pink color', () => {
+    const { getByText } = render(<Button color="pink.main">pink</Button>);
+    expect(getByText('pink')).toBeInTheDocument();
+  });
+  it('renders button with blue color', () => {
+    const { getByText } = render(<Button color="blue.main">blue</Button>);
+    expect(getByText('blue')).toBeInTheDocument();
+  });
+  it('renders button with purple color', () => {
+    const { getByText } = render(<Button color="purple.main">purple</Button>);
+    expect(getByText('purple')).toBeInTheDocument();
+  });
+  it('renders link', async () => {
+    const { getByRole } = render(<Button href="https://www.landbot.io">test</Button>);
+    expect(getByRole('link')).toBeInTheDocument();
+  });
+  it('renders disabled button', async () => {
+    const { getByRole } = render(<Button disabled>test</Button>);
+    expect(getByRole('button')).toBeDisabled();
+  });
+  it('should call onClick handler', async () => {
+    const onClickSpy = jest.fn();
+    const { getByRole } = render(
+      <Button onClick={onClickSpy} variant="text">
+        test
+      </Button>
+    );
+    const buttonElement = getByRole('button');
+    buttonElement.click();
+    expect(onClickSpy).toHaveBeenCalled();
   });
 });

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,14 +1,32 @@
 import React from 'react';
+import { StyledButton, StyledLink, StyledTypography } from './Button.styles';
+import { ButtonProps } from './types';
 
-export interface ButtonPropTypes {
-  label: string;
-  onClick?: () => void;
-}
+export const Button = ({
+  color = 'pink.main',
+  size = 'medium',
+  variant = 'contained',
+  disabled = false,
+  href,
+  children,
+  onClick,
+  ...rest
+}: ButtonProps) => {
+  const BaseButton = (href ? StyledLink : StyledButton) as React.ElementType;
 
-/**
-- Use a button for actions.
-- The label should always be present.
-**/
-export const Button = ({ label, onClick }: ButtonPropTypes) => {
-  return <button onClick={onClick}>{label}</button>;
+  return (
+    <BaseButton
+      $color={color}
+      $size={size}
+      $variant={variant}
+      disabled={disabled}
+      href={href}
+      onClick={onClick}
+      {...rest}
+    >
+      <StyledTypography $color={color} $variant={variant} as="span" disabled={disabled} variant="body1">
+        {children}
+      </StyledTypography>
+    </BaseButton>
+  );
 };

--- a/src/Button/constants.ts
+++ b/src/Button/constants.ts
@@ -1,0 +1,26 @@
+import { theme } from '../shared/theme';
+import { ColorTypes, SizeTypes } from './types';
+
+export const SIZES_MAPPING: Record<SizeTypes, string> = {
+  small: '24px',
+  medium: '32px',
+  large: '40px',
+};
+
+export const CONTAINED_HOVER_BACKGROUND_MAPPING: Record<ColorTypes, string> = {
+  'pink.main': theme.palette.pink[300],
+  'blue.main': theme.palette.blue[300],
+  'purple.main': theme.palette.purple[300],
+};
+
+export const DEFAULT_HOVER_BACKGROUND_MAPPING: Record<ColorTypes, string> = {
+  'pink.main': theme.palette.pink[100],
+  'blue.main': theme.palette.blue[100],
+  'purple.main': theme.palette.purple[100],
+};
+
+export const ACTIVE_MAPPING: Record<ColorTypes, string> = {
+  'pink.main': theme.palette.pink[600],
+  'blue.main': theme.palette.blue[600],
+  'purple.main': theme.palette.purple[600],
+};

--- a/src/Button/types.ts
+++ b/src/Button/types.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export type ButtonVariants = 'contained' | 'outlined' | 'text';
+export type ColorTypes = 'pink.main' | 'blue.main' | 'purple.main';
+export type SizeTypes = 'small' | 'medium' | 'large';
+
+type ButtonPropsBase = {
+  children: React.ReactNode;
+  disabled?: boolean;
+  href?: string;
+  color?: ColorTypes;
+  size?: SizeTypes;
+  variant?: ButtonVariants;
+};
+
+export type ButtonProps = ButtonPropsBase & (JSX.IntrinsicElements['a'] | JSX.IntrinsicElements['button']);

--- a/src/Button/utils.ts
+++ b/src/Button/utils.ts
@@ -1,0 +1,128 @@
+import { css } from 'styled-components';
+import type { Theme } from '../shared/theme.types';
+import { ACTIVE_MAPPING, CONTAINED_HOVER_BACKGROUND_MAPPING, DEFAULT_HOVER_BACKGROUND_MAPPING } from './constants';
+import { ButtonVariants, ColorTypes } from './types';
+
+export const getTypographyVariantStyles = (
+  theme: Theme,
+  color: ColorTypes,
+  variant: ButtonVariants,
+  disabled: boolean
+) => {
+  return {
+    contained: css`
+      color: ${getTypographyColorContained(theme, disabled)};
+    `,
+    outlined: css`
+      font-weight: bold;
+      color: ${getTypographyColorDefault(theme, color, disabled)};
+      &:active {
+        color: ${getActiveColor(variant, color, disabled)};
+      }
+    `,
+    text: css`
+      font-weight: bold;
+      color: ${getTypographyColorDefault(theme, color, disabled)};
+      &:active {
+        color: ${getActiveColor(variant, color, disabled)};
+      }
+    `,
+  }[variant];
+};
+
+export const getButtonVariantStyles = (theme: Theme, color: ColorTypes, variant: ButtonVariants, disabled: boolean) =>
+  ({
+    contained: css`
+      background-color: ${getBackgroundColor(theme, color, disabled)};
+      border-color: transparent;
+      border-radius: 4px;
+      &:hover {
+        background-color: ${getHoverBackgroundColor(variant, color, disabled)};
+      }
+      &:active {
+        background-color: ${getActiveColor(variant, color, disabled)};
+      }
+    `,
+    outlined: css`
+      background-color: white;
+      border-radius: 4px;
+      border: 1px solid ${getBorderColor(theme, color, disabled)};
+      &:hover {
+        background-color: ${getHoverBackgroundColor(variant, color, disabled)};
+      }
+      &:active {
+        border-color: ${getActiveColor(variant, color, disabled)};
+      }
+    `,
+    text: css`
+      border-color: transparent;
+      border-radius: 4px;
+      background-color: transparent;
+      &:hover {
+        background-color: ${getHoverBackgroundColor(variant, color, disabled)};
+      }
+    `,
+  }[variant]);
+
+export const getTypographyColorContained = (theme: Theme, disabled: boolean) => {
+  if (disabled) {
+    return theme.palette.neutral[200];
+  }
+  return theme.palette.white.main;
+};
+
+export const getTypographyColorDefault = (theme: Theme, color: ColorTypes, disabled: boolean) => {
+  if (disabled) {
+    return theme.palette.neutral[200];
+  }
+
+  return {
+    'pink.main': theme.palette.pink.main,
+    'blue.main': theme.palette.blue.main,
+    'purple.main': theme.palette.purple.main,
+  }[color];
+};
+
+export const getBackgroundColor = (theme: Theme, color: ColorTypes, disabled?: boolean) => {
+  if (disabled) {
+    return theme.palette.neutral[300];
+  }
+  return {
+    'pink.main': theme.palette.pink.main,
+    'blue.main': theme.palette.blue.main,
+    'purple.main': theme.palette.purple.main,
+  }[color];
+};
+
+export const getBorderColor = (theme: Theme, color: ColorTypes, disabled?: boolean) => {
+  if (disabled) {
+    return theme.palette.neutral[200];
+  }
+  return {
+    'pink.main': theme.palette.pink.main,
+    'blue.main': theme.palette.blue.main,
+    'purple.main': theme.palette.purple.main,
+  }[color];
+};
+
+export const getHoverBackgroundColor = (variant: ButtonVariants, color: ColorTypes, disabled?: boolean) => {
+  if (disabled) {
+    return null;
+  }
+  return {
+    contained: CONTAINED_HOVER_BACKGROUND_MAPPING[color],
+    outlined: DEFAULT_HOVER_BACKGROUND_MAPPING[color],
+    text: DEFAULT_HOVER_BACKGROUND_MAPPING[color],
+  }[variant];
+};
+
+export const getActiveColor = (variant: ButtonVariants, color: ColorTypes, disabled?: boolean) => {
+  if (disabled) {
+    return null;
+  }
+  return {
+    contained: ACTIVE_MAPPING[color],
+    outlined: ACTIVE_MAPPING[color],
+    text: ACTIVE_MAPPING[color],
+  }[variant];
+};

--- a/src/Toggle/Toggle.stories.tsx
+++ b/src/Toggle/Toggle.stories.tsx
@@ -14,8 +14,11 @@ export default {
   argTypes: {
     checked: { control: 'boolean' },
     disabled: { control: 'boolean' },
-    size: { control: 'radio', options: ['small', 'medium'], defaultValue: 'medium' },
+    size: { control: 'radio', options: ['small', 'medium'] },
     onChange: { action: 'onChange' },
+  },
+  args: {
+    size: 'medium',
   },
   parameters: {
     componentSubtitle: 'Displays a toggle switch',

--- a/src/shared/palette.ts
+++ b/src/shared/palette.ts
@@ -85,3 +85,7 @@ export const ERROR = {
   main: '#DD0E0E',
   light: '#FFC799',
 };
+
+export const WHITE = {
+  main: '#FFFFFF',
+};

--- a/src/shared/theme.ts
+++ b/src/shared/theme.ts
@@ -1,5 +1,5 @@
 import { Theme } from './theme.types';
-import { BLUE, ERROR, INFO, NEUTRAL, ORANGE, PINK, PURPLE, SUCCESS, TEAL, WARNING } from './palette';
+import { BLUE, ERROR, INFO, NEUTRAL, ORANGE, PINK, PURPLE, SUCCESS, TEAL, WARNING, WHITE } from './palette';
 
 export const theme: Theme = {
   base_spacing: 8,
@@ -14,10 +14,12 @@ export const theme: Theme = {
     info: INFO,
     warning: WARNING,
     error: ERROR,
+    white: WHITE,
   },
   typography: {
     font: {
-      primary: '\'DM Sans\', sans-serif',
+      // eslint-disable-next-line quotes
+      primary: "'DM Sans', sans-serif",
     },
   },
 };

--- a/src/shared/theme.types.ts
+++ b/src/shared/theme.types.ts
@@ -79,6 +79,9 @@ export interface Theme {
       main: string;
       light: string;
     };
+    white: {
+      main: string;
+    };
   };
   typography: {
     font: {
@@ -117,6 +120,7 @@ type SuccessColorsTypes = 'success.dark' | 'success.main' | 'success.light';
 type InfoColorsTypes = 'info.dark' | 'info.main' | 'info.light';
 type WarningColorsTypes = 'warning.dark' | 'warning.main' | 'warning.light';
 type ErrorColorsTypes = 'error.dark' | 'error.main' | 'error.light';
+type WhiteColorsTypes = 'white.main';
 
 export type ColorsTypes =
   | NeutralColorsTypes
@@ -128,4 +132,5 @@ export type ColorsTypes =
   | SuccessColorsTypes
   | InfoColorsTypes
   | WarningColorsTypes
-  | ErrorColorsTypes;
+  | ErrorColorsTypes
+  | WhiteColorsTypes;


### PR DESCRIPTION
API:

<html>
<body>
<!--StartFragment-->

Name | Type | Default | Description
-- | -- | -- | --
children | string |   | The button text
color | 'pink.main’ \| ‘blue.main’ \| ‘purple.main’ | 'pink.main' | The button color
disabled | bool | false | If true, the component is disabled.
fullWidth | bool | false | If true, the button will take up the full width of its container.
href | string |   | The URL to link to when the button is clicked. If defined, an a element will be used as the root node.
size | 'small' \| 'medium' \| 'large' | 'medium'  | The button size
variant | 'contained' \| 'outlined' \| 'text' | 'contained' | The button variant

<!--EndFragment-->
</body>
</html>