### PR TITLE
add full width prop to button component

### DIFF
--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -12,6 +12,7 @@ export default {
   argTypes: {
     children: { control: 'text' },
     disabled: { control: 'boolean' },
+    fullWidth: { control: 'boolean' },
   },
   args: {
     children: 'Button',
@@ -19,6 +20,7 @@ export default {
     size: 'medium',
     variant: 'contained',
     disabled: false,
+    fullWidth: false,
   },
 } as ComponentMeta<typeof Button>;
 

--- a/src/Button/Button.styles.ts
+++ b/src/Button/Button.styles.ts
@@ -6,6 +6,7 @@ import { getButtonVariantStyles, getTypographyVariantStyles } from './utils';
 
 interface StyledButtonProps {
   $color: ColorTypes;
+  $fullWidth: boolean;
   $size: SizeTypes;
   $variant: ButtonVariants;
   disabled: boolean;
@@ -24,6 +25,7 @@ const BaseButtonStyles = css<StyledButtonProps>`
   align-items: center;
   display: inline-flex;
   justify-content: center;
+  width: ${({ $fullWidth }) => ($fullWidth ? '100%' : undefined)};
   height: ${({ $size }) => SIZES_MAPPING[$size]};
   min-width: 80px;
   padding: 0 16px;

--- a/src/Button/Button.test.tsx
+++ b/src/Button/Button.test.tsx
@@ -51,6 +51,10 @@ describe('Button', () => {
     const { getByRole } = render(<Button disabled>test</Button>);
     expect(getByRole('button')).toBeDisabled();
   });
+  it('renders full width button', async () => {
+    const { getByRole } = render(<Button fullWidth>test</Button>);
+    expect(getByRole('button')).toBeInTheDocument();
+  });
   it('should call onClick handler', async () => {
     const onClickSpy = jest.fn();
     const { getByRole } = render(

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -7,6 +7,7 @@ export const Button = ({
   size = 'medium',
   variant = 'contained',
   disabled = false,
+  fullWidth = false,
   href,
   children,
   onClick,
@@ -17,6 +18,7 @@ export const Button = ({
   return (
     <BaseButton
       $color={color}
+      $fullWidth={fullWidth}
       $size={size}
       $variant={variant}
       disabled={disabled}

--- a/src/Button/types.ts
+++ b/src/Button/types.ts
@@ -6,9 +6,10 @@ export type SizeTypes = 'small' | 'medium' | 'large';
 
 type ButtonPropsBase = {
   children: React.ReactNode;
-  disabled?: boolean;
-  href?: string;
   color?: ColorTypes;
+  disabled?: boolean;
+  fullWidth?: boolean;
+  href?: string;
   size?: SizeTypes;
   variant?: ButtonVariants;
 };


### PR DESCRIPTION
Adds support for `fullWidth` prop, it sets the width to 100%, so it gets the width from the container.

