### PR TITLE
fix: disable body-max-line-length rule for commitlint

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,1 +1,6 @@
-module.exports = {extends: ['@commitlint/config-conventional']}
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [0, 'always', 100],
+  },
+};


### PR DESCRIPTION
This rule is not compatible with commits generated by semantic release.

Semantic release example:

<img width="893" alt="Screenshot 2022-12-20 at 11 48 13" src="https://user-images.githubusercontent.com/1252707/208649287-31b3a122-2ddb-4384-9e59-d4a3d94797be.png">

Error example:

```
stderr: '\x1B[34m→\x1B[39m No staged files match any configured task.\n' +
    '⧗   input: chore(release): 1.17.0 [skip ci]\n' +
    '\n' +
    '* add husky, lint-staged and commitlint ([f2ef008](https://github.com/landbot-org/lui/commit/f2ef00867a253e11366dcf118428fae8734ce0d5))\n' +
    "✖   body's lines must not be longer than 100 characters [body-max-line-length]\n" +
    '\n' +
    '✖   found 1 problems, 0 warnings\n' +
    'ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint\n' +
    '\n' +
    'husky - commit-msg hook exited with code 1 (error)',
```