### PR TITLE
fix(Tabs): fixes tab indicator

### DIFF
--- a/src/Tabs/Tabs.styles.ts
+++ b/src/Tabs/Tabs.styles.ts
@@ -1,8 +1,13 @@
 import styled, { css, keyframes } from 'styled-components';
+import { Box } from '../Box';
 import { Theme } from '../shared/theme.types';
 import { Typography } from '../Typography';
 import { SizeTypes } from './types';
 import { getButtonSizeStyles, getTabSizeStyles } from './utils';
+
+export const Container = styled(Box)`
+  height: 48px;
+`;
 
 export const ArrowButton = styled.div<{ $disabled: boolean; $size: SizeTypes }>`
   ${({ $size }) => getButtonSizeStyles($size)}

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -1,9 +1,8 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Box } from '../Box';
 import { Tab } from './Tab';
 import { Icon } from '../Icon';
-import { ArrowButton, TabsContainer } from './Tabs.styles';
+import { ArrowButton, Container, TabsContainer } from './Tabs.styles';
 import { TabsProps } from './types';
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { getButtonIconSizeStyles, getNextActiveTab, getPreviousActiveTab } from './utils';
@@ -40,7 +39,7 @@ export const Tabs = ({
   };
 
   return (
-    <Box display="flex">
+    <Container display="flex">
       {showScrollButtons && (
         <ArrowButton
           aria-label="navigation-left"
@@ -84,6 +83,6 @@ export const Tabs = ({
           <Icon icon={<FontAwesomeIcon icon={faChevronRight} />} size={getButtonIconSizeStyles(size)} />
         </ArrowButton>
       )}
-    </Box>
+    </Container>
   );
 };


### PR DESCRIPTION
If `showScrollButtons` is `false` and `showBottomLine` is `true`, when going from a tab to a previous tab, it shows a weird trailing effect. By setting the `height` of the container to `48px` this issue is resolved.

[Storybook link with current issue](https://638dbcc7869db28ad2ebd96d-crvxmrpoul.chromatic.com/)
[Storybook link with issue fixed generated by this PR](https://638dbcc7869db28ad2ebd96d-vcghjdwrsy.chromatic.com/)