### PR TITLE
fix(textarea): add forwardref and fix props typing

### DIFF
--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -6,25 +6,29 @@ import { Typography } from '../Typography';
 import { StyledTextArea } from './TextArea.styles';
 import { TextAreaProps } from './types';
 
-export const TextArea = ({ description, disabled, error, helperText, id, label, ...rest }: TextAreaProps) => (
-  <div>
-    {(label || description) && (
-      <FormLabel htmlFor={id}>
-        {label && (
-          <Typography variant="text14" fontWeight={700}>
-            {label}
-          </Typography>
-        )}
-        {description && <Typography variant="text14">{description}</Typography>}
-      </FormLabel>
-    )}
-    <Box display="flex">
-      <StyledTextArea {...rest} disabled={disabled} $disabled={disabled} $error={error} id={id} />
-    </Box>
-    {helperText && (
-      <FormHelperText variant="text12" color={error ? 'error.main' : 'neutral.main'}>
-        {helperText}
-      </FormHelperText>
-    )}
-  </div>
+export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  ({ description, disabled, error, helperText, id, label, ...rest }, ref) => (
+    <div>
+      {(label || description) && (
+        <FormLabel htmlFor={id}>
+          {label && (
+            <Typography variant="text14" fontWeight={700}>
+              {label}
+            </Typography>
+          )}
+          {description && <Typography variant="text14">{description}</Typography>}
+        </FormLabel>
+      )}
+      <Box display="flex">
+        <StyledTextArea {...rest} disabled={disabled} $disabled={disabled} $error={error} id={id} ref={ref} />
+      </Box>
+      {helperText && (
+        <FormHelperText variant="text12" color={error ? 'error.main' : 'neutral.main'}>
+          {helperText}
+        </FormHelperText>
+      )}
+    </div>
+  )
 );
+
+TextArea.displayName = 'TextArea';

--- a/src/TextArea/types.ts
+++ b/src/TextArea/types.ts
@@ -1,4 +1,4 @@
-export interface TextAreaProps extends React.InputHTMLAttributes<HTMLTextAreaElement> {
+export interface TextAreaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   label?: string;
   description?: string;
   error?: boolean;


### PR DESCRIPTION
- add forwardRef to interact with textarea from outside, for example, get the position of the cursor and add a string in a this specific position
- Change props typing to TextArea attributes. rows props was not working