### PR TITLE
feat(Button): text alignment prop

### DIFF
--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -107,3 +107,27 @@ ButtonLink.args = {
   href: '#',
   target: '_blank',
 };
+
+export const ButtonFullWidth: ComponentStory<typeof Button> = (args: ButtonProps) => (
+  <ThemeProvider theme={theme}>
+    <Button {...args}>Button</Button>
+  </ThemeProvider>
+);
+ButtonFullWidth.args = {
+  fullWidth: true,
+  size: 'large',
+};
+
+export const ButtonFullWidthBothIcons: ComponentStory<typeof Button> = (args: ButtonProps) => (
+  <ThemeProvider theme={theme}>
+    <Button {...args}>Select a date range</Button>
+  </ThemeProvider>
+);
+ButtonFullWidthBothIcons.args = {
+  color: 'white.main',
+  fullWidth: true,
+  textAlign: 'left',
+  size: 'large',
+  startIcon: <Robot />,
+  endIcon: <Icon icon={<FontAwesomeIcon icon={faArrowUpFromBracket} />} />,
+};

--- a/src/Button/Button.styles.ts
+++ b/src/Button/Button.styles.ts
@@ -1,6 +1,8 @@
 import styled, { css } from 'styled-components';
+import { Typography } from '../Typography';
+import type { TypographyProps } from '../Typography/types';
 import { SIZES_MAPPING } from './constants';
-import { ButtonVariants, ColorTypes, SizeTypes } from './types';
+import { ButtonVariants, ColorTypes, SizeTypes, TextAlignTypes } from './types';
 import { getButtonVariantStyles } from './utils';
 
 interface StyledButtonProps {
@@ -48,8 +50,18 @@ export const StyledSpinnerWrapper = styled.div`
 `;
 
 export const StyledContent = styled.div<StyledContentProps>`
+  flex-grow: 1;
   align-items: center;
   display: inline-flex;
 
   visibility: ${({ isLoading }) => (isLoading ? 'hidden' : 'visible')};
+`;
+
+interface StyledTypographyProps extends TypographyProps {
+  $textAlign?: TextAlignTypes;
+}
+
+export const StyledTypography = styled(Typography)<StyledTypographyProps>`
+  flex-grow: 1;
+  text-align: ${({ $textAlign }) => $textAlign};
 `;

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -3,8 +3,7 @@ import { Box } from '../Box';
 import { Icon } from '../Icon';
 import { Size } from '../Icon/types';
 import { Spinner } from '../Spinner';
-import { Typography } from '../Typography';
-import { StyledButton, StyledLink, StyledContent, StyledSpinnerWrapper } from './Button.styles';
+import { StyledButton, StyledLink, StyledContent, StyledSpinnerWrapper, StyledTypography } from './Button.styles';
 import { TYPOGRAPHY_VARIANT_MAPPING, SPINNER_VARIANT_MAPPING } from './constants';
 import { ButtonProps, SizeTypes } from './types';
 
@@ -22,6 +21,7 @@ export const Button = React.forwardRef<HTMLElement, ButtonProps>(
       startIcon,
       endIcon,
       onClick,
+      textAlign = 'center',
       ...rest
     },
     ref
@@ -63,9 +63,14 @@ export const Button = React.forwardRef<HTMLElement, ButtonProps>(
             </Box>
           )}
           {hasChildren && (
-            <Typography as={'span'} variant={TYPOGRAPHY_VARIANT_MAPPING[size]} fontWeight={700}>
+            <StyledTypography
+              $textAlign={textAlign}
+              forwardedAs={'span'}
+              variant={TYPOGRAPHY_VARIANT_MAPPING[size]}
+              fontWeight={700}
+            >
               {children}
-            </Typography>
+            </StyledTypography>
           )}
           {endIcon && (
             <Box display="flex" ml={hasChildren ? 1 : undefined}>

--- a/src/Button/types.ts
+++ b/src/Button/types.ts
@@ -3,6 +3,7 @@ import React from 'react';
 export type ButtonVariants = 'contained' | 'outlined' | 'text';
 export type ColorTypes = 'pink.main' | 'blue.main' | 'purple.main' | 'white.main';
 export type SizeTypes = 'small' | 'medium' | 'large';
+export type TextAlignTypes = 'left' | 'center' | 'right';
 
 type ButtonPropsBase = {
   children?: React.ReactNode;
@@ -15,6 +16,7 @@ type ButtonPropsBase = {
   variant?: ButtonVariants;
   startIcon?: JSX.Element;
   endIcon?: JSX.Element;
+  textAlign?: TextAlignTypes;
 };
 
 export type ButtonProps = ButtonPropsBase & (JSX.IntrinsicElements['a'] | JSX.IntrinsicElements['button']);


### PR DESCRIPTION
* Fixes icons position when full width button. Icons are placed in the start and the end of the button length, not in the middle.
* Added `textAlign` prop to set the position of the text when full width button.

<img width="749" alt="Captura de pantalla 2023-05-02 a las 13 47 36" src="https://user-images.githubusercontent.com/7536780/235658118-e34d88a0-65a1-4528-9a00-801994512b20.png">
