### PR TITLE
feat(Box): add prop color

### DIFF
--- a/src/Box/Box.stories.tsx
+++ b/src/Box/Box.stories.tsx
@@ -37,6 +37,7 @@ Default.args = {
   borderColor: 'neutral.300',
   display: 'block',
   elevation: 1,
+  radius: 0,
 };
 
 Default.play = async ({ canvasElement }) => {
@@ -57,7 +58,9 @@ Flexbox.args = {
       <p>row2</p>
     </>
   ),
+  color: 'blue.main',
   display: 'flex',
   elevation: 1,
   justifyContent: 'space-around',
+  radius: 0,
 };

--- a/src/Box/Box.styles.ts
+++ b/src/Box/Box.styles.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import BaseSpacing from '../BaseSpacing';
 
 import { StyledBoxProps } from './types';
-import { getBackgroundStyles, getBorderStyles, getElevationStyles, getRadiusStyles } from './utils';
+import { getBackgroundStyles, getBorderStyles, getColorStyles, getElevationStyles, getRadiusStyles } from './utils';
 
 export const BoxStyled = styled(BaseSpacing)<StyledBoxProps>`
   align-items: ${({ $alignItems }) => $alignItems};
@@ -15,6 +15,7 @@ export const BoxStyled = styled(BaseSpacing)<StyledBoxProps>`
   justify-content: ${({ $justifyContent }) => $justifyContent};
   gap: ${({ $gap }) => $gap && `${$gap}px`};
   ${getBackgroundStyles}
+  ${getColorStyles}
   ${getElevationStyles}
   ${getRadiusStyles}
   ${getBorderStyles}

--- a/src/Box/Box.tsx
+++ b/src/Box/Box.tsx
@@ -12,6 +12,7 @@ export const Box = React.forwardRef<HTMLElement, BoxProps>(
       borderColor,
       children,
       className,
+      color,
       display = 'block',
       elevation = 0,
       flexBasis,
@@ -33,6 +34,7 @@ export const Box = React.forwardRef<HTMLElement, BoxProps>(
       $backgroundColor={backgroundColor}
       $border={border}
       $borderColor={borderColor}
+      $color={color}
       $display={display}
       $elevation={elevation}
       $flexBasis={flexBasis}

--- a/src/Box/types.ts
+++ b/src/Box/types.ts
@@ -18,6 +18,7 @@ export interface BoxProps extends BaseSpacingProps, React.HTMLAttributes<HTMLDiv
   borderColor?: ColorsTypes;
   children?: React.ReactNode;
   className?: string;
+  color?: ColorsTypes;
   display?: DisplayType;
   elevation?: ElevationType;
   flexBasis?: string;
@@ -35,6 +36,7 @@ export interface StyledBoxProps extends BoxProps {
   $backgroundColor: BoxProps['backgroundColor'];
   $border: BoxProps['border'];
   $borderColor: BoxProps['borderColor'];
+  $color: BoxProps['color'];
   $display: BoxProps['display'];
   $elevation: BoxProps['elevation'];
   $flexBasis: BoxProps['flexBasis'];

--- a/src/Box/utils.ts
+++ b/src/Box/utils.ts
@@ -12,6 +12,14 @@ export const getBackgroundStyles = ({ $backgroundColor, theme }: StyledBoxProps 
   }
 };
 
+export const getColorStyles = ({ $color, theme }: StyledBoxProps & { theme: Theme }) => {
+  if ($color) {
+    return css`
+      color: ${getColorFromTheme(theme, $color)};
+    `;
+  }
+};
+
 export const getElevationStyles = ({ $elevation = 0 }: StyledBoxProps) =>
   css`
     box-shadow: ${BOX_SHADOW_MAPPING[$elevation]};


### PR DESCRIPTION
Added prop `color` to the component `Box`. Usage:
```typescript
<Box color="white.main" backgroundColor="blue.main" p={1}>Content</Box>
```