### PR TITLE
feat: add popover component

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "test": "jest",
+    "test:watch": "jest --watchAll",
     "test:ci": "jest --collect-coverage --ci",
     "test-storybook": "test-storybook",
     "lint": "eslint --ext=.tsx,.ts  src",

--- a/src/Popover/Popover.stories.tsx
+++ b/src/Popover/Popover.stories.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '../shared/theme';
+import { Popover } from './Popover';
+import { Box } from '../Box';
+import { PopoverProps } from './types';
+import { PopoverTrigger } from './PopoverTrigger';
+import { PopoverContent } from './PopoverContent';
+import { PopoverClose } from './PopoverClose';
+import { Typography } from '../Typography';
+
+export default {
+  title: 'Components/Popover',
+  component: Popover,
+} as ComponentMeta<typeof Popover>;
+
+export const Default: ComponentStory<typeof Popover> = (args: PopoverProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Box display="flex" justifyContent="center" m={10}>
+        <Popover {...args} open={open} onOpenChange={setOpen} preventClose>
+          <PopoverTrigger onClick={() => setOpen(true)}>Click here to open</PopoverTrigger>
+          <PopoverContent>
+            <Box display="flex" justifyContent="center" p={10} gap={12} backgroundColor="blue.50">
+              <Typography color="blue.main" variant="text12">
+                This is the popover content
+              </Typography>
+              <PopoverClose onClick={() => setOpen(false)}>X</PopoverClose>
+            </Box>
+          </PopoverContent>
+        </Popover>
+      </Box>
+    </ThemeProvider>
+  );
+};

--- a/src/Popover/Popover.test.tsx
+++ b/src/Popover/Popover.test.tsx
@@ -1,0 +1,84 @@
+import React, { ReactNode, useState } from 'react';
+import { Popover } from './Popover';
+import { PopoverTrigger } from './PopoverTrigger';
+import { PopoverContent } from './PopoverContent';
+import { PopoverClose } from './PopoverClose';
+import { act, mockResizeObserver, render, screen } from '../test-utils';
+
+interface SUTProps {
+  triggerContent: ReactNode;
+  popoverContent: ReactNode;
+  closeButtonContent: ReactNode;
+}
+
+const SUT = ({ triggerContent, popoverContent, closeButtonContent }: SUTProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger onClick={() => setOpen(true)}>{triggerContent}</PopoverTrigger>
+      <PopoverContent>
+        <div>
+          <div>{popoverContent}</div>
+          <PopoverClose onClick={() => setOpen(false)}>{closeButtonContent}</PopoverClose>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+const renderComponent = (props: Partial<SUTProps> = {}) => {
+  const defaultProps: SUTProps = {
+    popoverContent: <>Popover content</>,
+    triggerContent: <>Open popover</>,
+    closeButtonContent: <>Click to close</>,
+  };
+
+  return render(<SUT {...defaultProps} {...props} />);
+};
+
+describe('Popover', () => {
+  beforeEach(() => {
+    mockResizeObserver();
+  });
+
+  it('shows button to open popover', () => {
+    const popoverContent = 'popover.content';
+    const triggerContent = 'click-to-open';
+
+    renderComponent({ popoverContent, triggerContent });
+
+    expect(screen.getByRole('button', { name: triggerContent })).toBeVisible();
+    expect(screen.queryByText(popoverContent)).not.toBeInTheDocument();
+  });
+
+  it('shows popover content on click', async () => {
+    const popoverContent = 'popover.content';
+    const triggerContent = 'click-to-open';
+    const { user } = renderComponent({ popoverContent, triggerContent });
+
+    // TODO - review this act upgrade to last version
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: triggerContent }));
+    });
+
+    expect(screen.getByText(popoverContent)).toBeVisible();
+  });
+
+  it('hides popover content on close click', async () => {
+    const popoverContent = 'popover.content';
+    const triggerContent = 'click-to-open';
+    const closeButtonContent = 'click-to-close';
+    const { user } = renderComponent({ popoverContent, triggerContent, closeButtonContent });
+
+    // TODO - review this act upgrade to last version
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: triggerContent }));
+    });
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: closeButtonContent }));
+    });
+
+    expect(screen.queryByText(popoverContent)).not.toBeInTheDocument();
+  });
+});

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -1,0 +1,15 @@
+import React, { ReactNode } from 'react';
+import { PopoverProps } from './types';
+import { usePopover } from './usePopover';
+import { PopoverContext } from './PopoverContext';
+
+export const Popover = ({
+  children,
+  modal = false,
+  ...restOptions
+}: {
+  children: ReactNode;
+} & PopoverProps) => {
+  const popover = usePopover({ modal, ...restOptions });
+  return <PopoverContext.Provider value={popover}>{children}</PopoverContext.Provider>;
+};

--- a/src/Popover/PopoverClose.tsx
+++ b/src/Popover/PopoverClose.tsx
@@ -1,0 +1,18 @@
+import React, { ButtonHTMLAttributes, ForwardedRef, forwardRef } from 'react';
+import { usePopoverContext } from './PopoverContext';
+
+const PopoverCloseBase = (props: ButtonHTMLAttributes<HTMLButtonElement>, ref: ForwardedRef<HTMLButtonElement>) => {
+  const { setOpen } = usePopoverContext();
+  return (
+    <button
+      type="button"
+      ref={ref}
+      {...props}
+      onClick={(event) => {
+        props.onClick?.(event);
+        setOpen(false);
+      }}
+    />
+  );
+};
+export const PopoverClose = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(PopoverCloseBase);

--- a/src/Popover/PopoverContent.tsx
+++ b/src/Popover/PopoverContent.tsx
@@ -1,0 +1,33 @@
+import React, { ForwardedRef, HTMLProps, forwardRef } from 'react';
+import { usePopoverContext } from './PopoverContext';
+import { FloatingFocusManager, FloatingPortal, useMergeRefs } from '@floating-ui/react';
+
+const PopoverContentBase = (props: HTMLProps<HTMLDivElement>, propRef: ForwardedRef<HTMLDivElement>) => {
+  {
+    const { context: floatingContext, ...context } = usePopoverContext();
+    const ref = useMergeRefs([context.refs.setFloating, propRef]);
+
+    if (!floatingContext.open) return null;
+
+    return (
+      <FloatingPortal>
+        <FloatingFocusManager context={floatingContext} modal={context.modal}>
+          <div
+            ref={ref}
+            style={{
+              ...context.floatingStyles,
+              ...props.style,
+            }}
+            aria-labelledby={context.labelId}
+            aria-describedby={context.descriptionId}
+            {...context.getFloatingProps(props)}
+          >
+            {props.children}
+          </div>
+        </FloatingFocusManager>
+      </FloatingPortal>
+    );
+  }
+};
+
+export const PopoverContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivElement>>(PopoverContentBase);

--- a/src/Popover/PopoverContext.tsx
+++ b/src/Popover/PopoverContext.tsx
@@ -1,0 +1,21 @@
+import React, { useContext } from 'react';
+import { usePopover } from './usePopover';
+
+type ContextType =
+  | (ReturnType<typeof usePopover> & {
+      setLabelId: React.Dispatch<React.SetStateAction<string | undefined>>;
+      setDescriptionId: React.Dispatch<React.SetStateAction<string | undefined>>;
+    })
+  | null;
+
+export const PopoverContext = React.createContext<ContextType>(null);
+
+export const usePopoverContext = () => {
+  const context = useContext(PopoverContext);
+
+  if (context === null) {
+    throw new Error('Popover components must be wrapped in <Popover />');
+  }
+
+  return context;
+};

--- a/src/Popover/PopoverTrigger.tsx
+++ b/src/Popover/PopoverTrigger.tsx
@@ -1,0 +1,35 @@
+import React, { ReactNode } from 'react';
+import { usePopoverContext } from './PopoverContext';
+import { useMergeRefs } from '@floating-ui/react';
+
+interface PopoverTriggerProps {
+  children: ReactNode;
+  asChild?: boolean;
+}
+
+export const PopoverTrigger = React.forwardRef<HTMLElement, React.HTMLProps<HTMLElement> & PopoverTriggerProps>(
+  function PopoverTrigger({ children, asChild = false, ...props }, propRef) {
+    const context = usePopoverContext();
+    const childrenRef = (children as any).ref;
+    const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef]);
+
+    // `asChild` allows the user to pass any element as the anchor
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(
+        children,
+        context.getReferenceProps({
+          ref,
+          ...props,
+          ...children.props,
+          'data-state': context.open ? 'open' : 'closed',
+        })
+      );
+    }
+
+    return (
+      <button ref={ref} type="button" {...context.getReferenceProps(props)}>
+        {children}
+      </button>
+    );
+  }
+);

--- a/src/Popover/PopoverTrigger.tsx
+++ b/src/Popover/PopoverTrigger.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ForwardedRef, HTMLProps, ReactNode, forwardRef } from 'react';
 import { usePopoverContext } from './PopoverContext';
 import { useMergeRefs } from '@floating-ui/react';
 
@@ -6,16 +6,19 @@ interface PopoverTriggerProps {
   children: ReactNode;
 }
 
-export const PopoverTrigger = React.forwardRef<HTMLElement, React.HTMLProps<HTMLElement> & PopoverTriggerProps>(
-  function PopoverTrigger({ children, ...props }, propRef) {
-    const context = usePopoverContext();
-    const childrenRef = (children as any).ref;
-    const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef]);
+const PopoverTriggerBase = (
+  { children, ...props }: HTMLProps<HTMLElement> & PopoverTriggerProps,
+  propRef: ForwardedRef<HTMLElement>
+) => {
+  const context = usePopoverContext();
+  const childrenRef = (children as any).ref;
+  const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef]);
 
-    return (
-      <button ref={ref} type="button" {...context.getReferenceProps(props)}>
-        {children}
-      </button>
-    );
-  }
-);
+  return (
+    <button ref={ref} type="button" {...context.getReferenceProps(props)}>
+      {children}
+    </button>
+  );
+};
+
+export const PopoverTrigger = forwardRef<HTMLElement, HTMLProps<HTMLElement> & PopoverTriggerProps>(PopoverTriggerBase);

--- a/src/Popover/PopoverTrigger.tsx
+++ b/src/Popover/PopoverTrigger.tsx
@@ -4,27 +4,13 @@ import { useMergeRefs } from '@floating-ui/react';
 
 interface PopoverTriggerProps {
   children: ReactNode;
-  asChild?: boolean;
 }
 
 export const PopoverTrigger = React.forwardRef<HTMLElement, React.HTMLProps<HTMLElement> & PopoverTriggerProps>(
-  function PopoverTrigger({ children, asChild = false, ...props }, propRef) {
+  function PopoverTrigger({ children, ...props }, propRef) {
     const context = usePopoverContext();
     const childrenRef = (children as any).ref;
     const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef]);
-
-    // `asChild` allows the user to pass any element as the anchor
-    if (asChild && React.isValidElement(children)) {
-      return React.cloneElement(
-        children,
-        context.getReferenceProps({
-          ref,
-          ...props,
-          ...children.props,
-          'data-state': context.open ? 'open' : 'closed',
-        })
-      );
-    }
 
     return (
       <button ref={ref} type="button" {...context.getReferenceProps(props)}>

--- a/src/Popover/index.ts
+++ b/src/Popover/index.ts
@@ -1,0 +1,4 @@
+export * from './Popover';
+export * from './PopoverClose';
+export * from './PopoverContent';
+export * from './PopoverTrigger';

--- a/src/Popover/types.ts
+++ b/src/Popover/types.ts
@@ -1,0 +1,10 @@
+import { Placement } from '@floating-ui/react';
+
+export interface PopoverProps {
+  initialOpen?: boolean;
+  placement?: Placement;
+  modal?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  preventClose?: boolean;
+}

--- a/src/Popover/usePopover.ts
+++ b/src/Popover/usePopover.ts
@@ -1,0 +1,68 @@
+import {
+  useFloating,
+  autoUpdate,
+  offset,
+  flip,
+  arrow,
+  useClick,
+  useDismiss,
+  useRole,
+  useInteractions,
+} from '@floating-ui/react';
+import React, { useRef, useState } from 'react';
+import { PopoverProps } from './types';
+
+const ARROW_HEIGHT = 7;
+const GAP = 2;
+
+export const usePopover = ({
+  initialOpen = false,
+  placement = 'bottom',
+  modal,
+  open: controlledOpen,
+  onOpenChange: setControlledOpen,
+  preventClose = false,
+}: PopoverProps = {}) => {
+  const arrowRef = useRef(null);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(initialOpen);
+  const [labelId, setLabelId] = useState<string | undefined>();
+  const [descriptionId, setDescriptionId] = useState<string | undefined>();
+
+  const open = controlledOpen ?? uncontrolledOpen;
+  const setOpen = setControlledOpen ?? setUncontrolledOpen;
+
+  const data = useFloating({
+    placement,
+    open,
+    onOpenChange: setOpen,
+    whileElementsMounted: autoUpdate,
+    middleware: [
+      offset(ARROW_HEIGHT + GAP),
+      arrow({
+        element: arrowRef,
+      }),
+      flip(),
+    ],
+  });
+
+  const click = useClick(data.context, { enabled: controlledOpen === null });
+  const dismiss = useDismiss(data.context, { enabled: !preventClose });
+  const role = useRole(data.context);
+
+  const interactions = useInteractions([click, dismiss, role]);
+
+  return React.useMemo(
+    () => ({
+      open,
+      setOpen,
+      ...interactions,
+      ...data,
+      modal,
+      labelId,
+      descriptionId,
+      setLabelId,
+      setDescriptionId,
+    }),
+    [open, setOpen, interactions, data, modal, labelId, descriptionId]
+  );
+};

--- a/src/Tooltip/Tooltip.test.tsx
+++ b/src/Tooltip/Tooltip.test.tsx
@@ -2,27 +2,10 @@ import { screen } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { Button } from '../Button';
-import { render } from '../test-utils';
+import { mockResizeObserver, render } from '../test-utils';
 import { Typography } from '../Typography';
 import { Tooltip } from './Tooltip';
 import { TooltipProps } from './types';
-
-class ResizeObserver {
-  callback: globalThis.ResizeObserverCallback;
-  constructor(callback: globalThis.ResizeObserverCallback) {
-    this.callback = callback;
-  }
-  observe(target: Element) {
-    this.callback([{ target } as globalThis.ResizeObserverEntry], this);
-  }
-  //eslint-disable-next-line @typescript-eslint/no-empty-function
-  unobserve() {}
-
-  //eslint-disable-next-line @typescript-eslint/no-empty-function
-  disconnect() {}
-}
-
-global.ResizeObserver = ResizeObserver;
 
 const renderComponent = (props: Partial<TooltipProps> = {}) =>
   render(
@@ -32,6 +15,10 @@ const renderComponent = (props: Partial<TooltipProps> = {}) =>
   );
 
 describe('Tooltip', () => {
+  beforeEach(() => {
+    mockResizeObserver();
+  });
+
   it('should render children', () => {
     renderComponent();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { Checkbox } from './Checkbox';
 export { Divider } from './Divider';
 export { Icon, GRID_AREA } from './Icon';
 export { Link } from './Link';
+export * from './Popover';
 export { Radio } from './Radio';
 export { Spinner } from './Spinner';
 export { Tabs } from './Tabs';

--- a/src/test-utils/helpers/index.ts
+++ b/src/test-utils/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './mockResizeObserver';

--- a/src/test-utils/helpers/mockResizeObserver.ts
+++ b/src/test-utils/helpers/mockResizeObserver.ts
@@ -1,0 +1,5 @@
+import { ResizeObserver } from '../mocks';
+
+export const mockResizeObserver = () => {
+  global.ResizeObserver = ResizeObserver;
+};

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1,0 +1,3 @@
+export * from '@testing-library/react';
+export { render } from './render';
+export * from './helpers';

--- a/src/test-utils/mocks/ResizeObserver.tsx
+++ b/src/test-utils/mocks/ResizeObserver.tsx
@@ -1,0 +1,14 @@
+export class ResizeObserver {
+  callback: globalThis.ResizeObserverCallback;
+  constructor(callback: globalThis.ResizeObserverCallback) {
+    this.callback = callback;
+  }
+  observe(target: Element) {
+    this.callback([{ target } as globalThis.ResizeObserverEntry], this);
+  }
+  //eslint-disable-next-line @typescript-eslint/no-empty-function
+  unobserve() {}
+
+  //eslint-disable-next-line @typescript-eslint/no-empty-function
+  disconnect() {}
+}

--- a/src/test-utils/mocks/index.ts
+++ b/src/test-utils/mocks/index.ts
@@ -1,0 +1,1 @@
+export * from './ResizeObserver';

--- a/src/test-utils/render.tsx
+++ b/src/test-utils/render.tsx
@@ -2,9 +2,9 @@ import React, { ReactElement } from 'react';
 import { render as rtlRender, RenderOptions } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from 'styled-components';
-import { theme } from './shared/theme';
+import { theme } from '../shared/theme';
 
-const render = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) => {
+export const render = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) => {
   function Wrapper({ children }: { children?: React.ReactNode }) {
     return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
   }
@@ -14,6 +14,3 @@ const render = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) => {
     ...rtlRender(ui, { wrapper: Wrapper, ...options }),
   };
 };
-
-export * from '@testing-library/react';
-export { render };


### PR DESCRIPTION
- `<Popover>` es el padre que lo envuelve todo
- `<PopoverTrigger>` es el botón que abrirá el popover. Básicamente un button con children
- `<PopoverContent>`  contiene el componente a mostrar cuando esté abierto
- `<PopoverClose>` es el botón para cerrar. Al igual que antes un botón con children. Este es opcional no hace falta ponerlo

También tenemos una propiedad  `preventClose` para especificar si queremos que permanezca abierto al hacer click fuera del popover.

Se basa en el ejemplo [de la docu](https://floating-ui.com/docs/popover#reusable-popover-component)

**IMPORTANTE**: Querido reviewer, si levantas storybook, ten en cuenta que algunas de las properties están puestas a pincho. Así que aunque storybook the ofrece cambiarlas, pues básicamente ,no puedes. 😅 