### PR TITLE
feat: make tooltips clickable when hover

### DIFF
--- a/src/Tooltip/Tooltip.stories.tsx
+++ b/src/Tooltip/Tooltip.stories.tsx
@@ -69,3 +69,20 @@ export const FlipTooltip: ComponentStory<typeof Tooltip> = (args: TooltipProps) 
     </Box>
   </ThemeProvider>
 );
+
+export const ClickableContentTooltip: ComponentStory<typeof Tooltip> = (args: TooltipProps) => (
+  <ThemeProvider theme={theme}>
+    <Box display="flex" justifyContent="center" py={20} m={10} style={{ height: '550px', overflowY: 'hidden' }}>
+      <Tooltip
+        {...args}
+        content={
+          <Typography color={args.color === 'white' ? 'blue.main' : 'white.main'} variant="text12">
+            This is the content of Tooltip! <a href="https://www.google.com">This is a link</a>
+          </Typography>
+        }
+      >
+        <Button size="large">Interact with me and click the link!</Button>
+      </Tooltip>
+    </Box>
+  </ThemeProvider>
+);

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -11,6 +11,7 @@ import {
   autoUpdate,
   useClick,
   useDismiss,
+  safePolygon,
 } from '@floating-ui/react';
 import { TooltipProps } from './types';
 import { StyledContent, StyledWrapperChildren } from './Tooltip.styles';
@@ -43,7 +44,10 @@ export const Tooltip = ({
     ],
   });
   const role = useRole(context, { role: 'tooltip' });
-  const hover = useHover(context, { enabled: interaction === 'hover' });
+  const hover = useHover(context, {
+    enabled: interaction === 'hover',
+    handleClose: safePolygon({ buffer: -Infinity, blockPointerEvents: true }),
+  });
   const click = useClick(context, { enabled: interaction === 'click' });
   const dismiss = useDismiss(context);
 


### PR DESCRIPTION
## Description

The idea behind this MR is to make the content of the tooltip interactive if needed. We do this be defining a square safe polygon to be able to hover tooltip contents and also blocking pointer events to be able to click inside tooltip content.

## Preview


https://github.com/landbot-org/lui/assets/650592/4c7225c5-8d84-426c-9b42-b22981ec9fb8

