### PR TITLE
feat(Shared): add orange 100 (#FFE0A9) color

### DIFF
--- a/src/shared/palette.ts
+++ b/src/shared/palette.ts
@@ -56,6 +56,7 @@ export const PURPLE = {
 
 export const ORANGE = {
   main: '#F58B0B',
+  100: '#FFE0A9',
   200: '#FCC76B',
   400: '#F9B96D',
   600: '#B05305',


### PR DESCRIPTION
Add color orange 100 (#FFE0A9):

![image](https://github.com/landbot-org/lui/assets/137399389/64e46868-42e2-4788-922f-eb4c3a298d8f)
