### PR TITLE
fix(Tabs): allow the active tab management from the outside

### DIFF
--- a/src/Tabs/Tabs.stories.tsx
+++ b/src/Tabs/Tabs.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { theme } from '../shared/theme';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { ThemeProvider } from 'styled-components';
@@ -48,10 +48,11 @@ export default {
 } as ComponentMeta<typeof TabsComponent>;
 
 export const Tabs: ComponentStory<typeof TabsComponent> = (args: TabsProps) => {
+  const [active, setActive] = useState<number>(3);
   return (
     <ThemeProvider theme={theme}>
       <Box backgroundColor="neutral.300" py={5} px={5} style={{ width: '400px' }}>
-        <TabsComponent {...args} />
+        <TabsComponent {...args} value={active} onChange={(newActive) => setActive(newActive)} />
       </Box>
     </ThemeProvider>
   );

--- a/src/Tabs/Tabs.test.tsx
+++ b/src/Tabs/Tabs.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '../test-utils';
-import { cleanup } from '@testing-library/react';
+import { act, cleanup } from '@testing-library/react';
 import { Tabs } from './Tabs';
 
 afterEach(cleanup);
@@ -23,28 +23,36 @@ describe('Tabs component', () => {
     },
   ];
 
-  it('should render the correct number of tabs', () => {
-    render(<Tabs tabs={tabProps} onChange={jest.fn} />);
+  it('should show the configured tabs when it is loaded', () => {
+    render(<Tabs tabs={tabProps} onChange={jest.fn} value={0} />);
     const tabs = screen.getAllByRole('tab');
 
     expect(tabs).toHaveLength(tabs.length);
   });
 
-  it('should set the correct active tab when clicked', async () => {
-    const { user } = render(<Tabs tabs={tabProps} onChange={jest.fn} />);
+  it('should show as selected the active tab', () => {
+    render(<Tabs tabs={tabProps} onChange={jest.fn} value={1} />);
     const tabs = screen.getAllByRole('tab');
-
-    await user.click(tabs[1]);
 
     expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('should not set active tab when a disabled tab is clicked', async () => {
-    const { user } = render(<Tabs tabs={tabProps} onChange={jest.fn} />);
-    const tabs = screen.getAllByRole('tab');
+  it('should fire an onChange event when user clicks on a tab', async () => {
+    const onChangeSpy = jest.fn();
+    const { user } = render(<Tabs tabs={tabProps} onChange={onChangeSpy} value={0} />);
+    
+    await act(async () => await user.click(screen.getByRole('tab', { name: 'Tab 2'})));
 
-    await user.click(tabs[2]);
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenCalledWith(1);
+  });
 
-    expect(tabs[2]).not.toHaveAttribute('aria-selected', 'true');
+  it('should not fire an onChange event when user clicks a disabled tab', async () => {
+    const onChangeSpy = jest.fn();
+    const { user } = render(<Tabs tabs={tabProps} onChange={jest.fn}  />);
+
+    await act(async () => await user.click(screen.getByRole('tab', { name: 'Tab 3'})));
+
+    expect(onChangeSpy).toHaveBeenCalledTimes(0);
   });
 });


### PR DESCRIPTION
We need to integrate the tabs control in our sidebar; we need to manage the active tab from the sidebar or other external effects.

For that reason, after an analysis, improving the Tab control to give this capacity is a quick win.