### PR TITLE
feat: allow null as value

### DIFF
--- a/src/TextField/TextField.styles.ts
+++ b/src/TextField/TextField.styles.ts
@@ -13,7 +13,7 @@ import { pxToRem } from '../shared/mixins';
 interface FormInputProps {
   theme: Theme;
   $disabled?: boolean;
-  $error?: boolean;
+  $error?: boolean | null;
 }
 
 export const StyledInputGroup = styled.div<FormInputProps>`

--- a/src/TextField/types.ts
+++ b/src/TextField/types.ts
@@ -4,8 +4,8 @@ export interface TextFieldProps extends React.InputHTMLAttributes<HTMLInputEleme
   label?: string;
   description?: string;
   endAdornment?: React.ReactNode;
-  error?: boolean;
-  helperText?: string;
+  error?: boolean | null;
+  helperText?: string | null;
   startAdornment?: React.ReactNode;
   inputRef?: React.RefObject<HTMLInputElement>;
   inputGroupProps?: React.HTMLAttributes<HTMLDivElement>;

--- a/src/shared/inputStyles.ts
+++ b/src/shared/inputStyles.ts
@@ -5,7 +5,7 @@ import { pxToRem } from './mixins';
 interface InputStylesProps {
   theme: Theme;
   $disabled?: boolean;
-  $error?: boolean;
+  $error?: boolean | null;
 }
 
 export const inputBorderStyle = css<InputStylesProps>`


### PR DESCRIPTION
We allow null as posible value, to be consistent with `null` initializations h[ere](https://git.yexir.com/landbot/landbot/-/commit/062355bf71192bca699339c40ebe85187f841c36)