### PR TITLE
fix: improve Icon storybook

### DIFF
--- a/src/Icon/Icon.stories.tsx
+++ b/src/Icon/Icon.stories.tsx
@@ -1,34 +1,20 @@
 import React from 'react';
-import { ThemeProvider } from 'styled-components';
+import styled, { ThemeProvider } from 'styled-components';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { faRobot } from '@fortawesome/free-solid-svg-icons';
 import { theme } from '../shared/theme';
 import { Icon } from './Icon';
 import * as icons from './icons';
 import { IconProps } from './types';
-import { Box } from '../Box';
 import { Typography } from '../Typography';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Divider } from '../Divider';
+import { Box } from '../Box';
 
 export default {
   title: 'Components/Icon',
   component: Icon,
   argTypes: {
-    color: {
-      control: {
-        type: 'select',
-      },
-    },
-    gridArea: {
-      control: {
-        type: 'select',
-      },
-    },
-    size: {
-      control: {
-        type: 'select',
-      },
-    },
     icon: {
       control: {
         type: null,
@@ -38,105 +24,69 @@ export default {
   parameters: {
     componentSubtitle: 'Displays a landbot icon',
   },
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={theme}>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
 } as ComponentMeta<typeof Icon>;
 
-const TemplateCalendly: ComponentStory<typeof Icon> = (args: {
-  gridArea?: IconProps['gridArea'];
-  size?: IconProps['size'];
-}) => {
+const GridBox = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  grid-gap: 8px;
+`;
+
+const GridItem = styled(Box).attrs({
+  radius: 3,
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+})`
+  height: 80px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.palette.blue[100]};
+  }
+`;
+
+export const Icons: ComponentStory<typeof Icon> = (args: IconProps) => {
+  const handleClick = (iconName: string) => navigator.clipboard.writeText(`<${iconName} />`);
+
   return (
-    <ThemeProvider theme={theme}>
-      <Icon icon={<icons.Calendly />} size={args.size} gridArea={args.gridArea} />
-    </ThemeProvider>
-  );
-};
-
-export const Calendly = TemplateCalendly.bind({});
-
-const TemplateFontAwesome: ComponentStory<typeof Icon> = (args: {
-  color?: IconProps['color'];
-  gridArea?: IconProps['gridArea'];
-  size?: IconProps['size'];
-}) => {
-  return (
-    <ThemeProvider theme={theme}>
-      <Icon icon={<FontAwesomeIcon icon={faRobot} />} size={args.size} color={args.color} gridArea={args.gridArea} />
-    </ThemeProvider>
-  );
-};
-
-export const FontAwesome = TemplateFontAwesome.bind({});
-
-const INTEGRATION_ICONS = [
-  'Airtable',
-  'Hubspot',
-  'Dialogflow',
-  'Zapier',
-  'GoogleSheets',
-  'Analytics',
-  'Sunco',
-  'Calendly',
-  'Salesforce',
-  'Segment',
-  'Airtable',
-  'Mailchimp',
-  'Stripe',
-  'Slack',
-  'Whatsapp',
-  'WhatsappTesting',
-  'Wix',
-  'MessengerNew',
-  'Messenger',
-  'API',
-  'MessageHooks',
-  'PlatformAPI',
-  'Brick',
-  'BrickBlue',
-  'BrickDefault',
-  'BrickOrange',
-  'BrickPink',
-  'BrickPurple',
-  'BrickTeal',
-];
-
-const TemplateIntegrationsandBricks = ({ size, gridArea }: IconProps) => {
-  return (
-    <ThemeProvider theme={theme}>
-      <Box display="flex" flexDirection="row" flexWrap="wrap">
-        {INTEGRATION_ICONS.map((icon) => {
-          const IconRender = icons[icon as keyof typeof icons];
+    <>
+      <Typography variant="subtitle2">Click to copy an icon component (e.g. &lt;Calendly /&gt;)</Typography>
+      <Box mt={1} mb={3}>
+        <Divider />
+      </Box>
+      <GridBox>
+        {Object.keys(icons).map((iconName) => {
+          const IconRender = icons[iconName as keyof typeof icons];
           return (
-            <Box key={icon} display="flex" flexDirection="column" alignItems="center" m={4} title={icon}>
-              <Typography>{icon}</Typography>
-              <Icon icon={<IconRender />} size={size} gridArea={gridArea} />
-            </Box>
+            <GridItem key={iconName} title={iconName} onClick={() => handleClick(iconName)}>
+              <Icon {...args} icon={<IconRender />} />
+              <Typography ellipsize>{iconName}</Typography>
+            </GridItem>
           );
         })}
-      </Box>
-    </ThemeProvider>
+      </GridBox>
+    </>
   );
 };
 
-export const IntegrationsAndBricks = TemplateIntegrationsandBricks.bind({});
-
-const TemplateEmojis = ({ size, gridArea }: IconProps) => {
-  return (
-    <ThemeProvider theme={theme}>
-      <Box display="flex" flexDirection="row" flexWrap="wrap">
-        {Object.keys(icons).map((icon) => {
-          if (!INTEGRATION_ICONS.includes(icon)) {
-            const IconRender = icons[icon as keyof typeof icons];
-            return (
-              <Box key={icon} display="flex" flexDirection="column" alignItems="center" m={4} title={icon}>
-                <Typography>{icon}</Typography>
-                <Icon icon={<IconRender />} size={size} gridArea={gridArea} />
-              </Box>
-            );
-          }
-        })}
-      </Box>
-    </ThemeProvider>
-  );
+Icons.args = {
+  size: '2x',
 };
 
-export const Emojis = TemplateEmojis.bind({});
+export const FontAwesomeExample: ComponentStory<typeof Icon> = (args: IconProps) => {
+  return <Icon {...args} icon={<FontAwesomeIcon icon={faRobot} />} />;
+};
+
+FontAwesomeExample.args = {
+  size: '2x',
+  color: 'pink.main',
+};


### PR DESCRIPTION
* Unified list of icons story into one. All icons are added automatically to the list.
* When clicking an Icon, the component string is copied into clipboard (e.g. `<Calendly />`)
* List of icons are presented alphabetically in a grid with a greater size so they can be easily identified.

<img width="1436" alt="Captura de pantalla 2023-12-20 a las 13 09 43" src="https://github.com/landbot-org/lui/assets/7536780/4d43378e-e372-4031-b0b7-42c0cea6bf4b">
