### PR TITLE
feat(peerDependencies): allow react version greater than or equal to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   },
   "homepage": "https://github.com/landbot-org/lui#readme",
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.22.1",
     "styled-components": "^6.1.2"
   },


### PR DESCRIPTION
BREAKING CHANGE: changes in peerdependencies

We are using features from react 18 like useId hook