### PR TITLE
feat: add onFocus prop to RichTextEditor

### DIFF
--- a/src/components/rich-text-editor/RichTextEditor.test.tsx
+++ b/src/components/rich-text-editor/RichTextEditor.test.tsx
@@ -101,6 +101,16 @@ describe('RichTextEditor', () => {
     });
   });
 
+  it('should call onFocus when editor is focused', async () => {
+    const onFocus = jest.fn();
+    const label = 'Label';
+    const { user } = render(<RichTextEditor label={label} onFocus={onFocus} />);
+
+    await user.click(screen.getByRole('textbox'));
+
+    expect(onFocus).toHaveBeenCalled();
+  });
+
   it('should limit the number of characters', async () => {
     const maxLength = 10;
     const { user } = render(<RichTextEditor maxLength={maxLength} />);

--- a/src/components/rich-text-editor/RichTextEditor.tsx
+++ b/src/components/rich-text-editor/RichTextEditor.tsx
@@ -22,6 +22,7 @@ import { RichTextEditorProps } from './RichTextEditor.types';
 import { getInputState, getOutput } from './RichTextEditor.utils';
 import { CodeHighlightPlugin } from './plugins/CodeHighlightPlugin';
 import { MaxLengthPlugin } from './plugins/MaxLengthPlugin';
+import { OnFocusPlugin } from './plugins/OnFocusPlugin';
 import { ToolbarPlugin } from './plugins/ToolbarPlugin';
 
 import {
@@ -36,6 +37,7 @@ import {
 export const RichTextEditor = ({
   inputFormat = 'json',
   onChange,
+  onFocus,
   placeholder,
   readOnly,
   error,
@@ -110,6 +112,7 @@ export const RichTextEditor = ({
             />
           </StyledContentEditableWrapper>
           <OnChangePlugin onChange={handleChange} ignoreSelectionChange ignoreHistoryMergeTagChange />
+          {onFocus && <OnFocusPlugin onFocus={onFocus} />}
           <HistoryPlugin />
           <CodeHighlightPlugin />
           <ListPlugin />

--- a/src/components/rich-text-editor/RichTextEditor.types.ts
+++ b/src/components/rich-text-editor/RichTextEditor.types.ts
@@ -14,6 +14,7 @@ export interface RichTextEditorProps {
     markdownString: string;
     text: string;
   }) => void;
+  onFocus?: () => void;
   placeholder?: string;
   readOnly?: boolean;
   error?: boolean;

--- a/src/components/rich-text-editor/plugins/OnFocusPlugin.ts
+++ b/src/components/rich-text-editor/plugins/OnFocusPlugin.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { COMMAND_PRIORITY_LOW, FOCUS_COMMAND } from 'lexical';
+
+export const OnFocusPlugin = ({ onFocus }: { onFocus: () => void }) => {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return editor.registerCommand(
+      FOCUS_COMMAND,
+      () => {
+        onFocus();
+        return false;
+      },
+      COMMAND_PRIORITY_LOW,
+    );
+  }, [editor, onFocus]);
+
+  return null;
+};


### PR DESCRIPTION
Added optional prop `onFocus` to detect focus events on the `RichTextEditor` component.