### PR TITLE
fix: dialog overlay z-index

### DIFF
--- a/src/components/dialog/Dialog.styles.ts
+++ b/src/components/dialog/Dialog.styles.ts
@@ -1,9 +1,9 @@
 import { styled } from 'styled-components';
 import { Box } from '../box';
 
-export const StyledContent = styled(Box)<{ $width: number }>`
+export const StyledContent = styled(Box)<{ $width: number; $zIndex: number }>`
   position: relative;
-  z-index: 1000;
+  z-index: ${({ $zIndex }) => $zIndex};
   width: ${({ $width }) => `${$width}px`};
   max-width: 95vw;
   max-height: 95vh;

--- a/src/components/dialog/Dialog.types.ts
+++ b/src/components/dialog/Dialog.types.ts
@@ -8,4 +8,5 @@ export interface DialogProps {
   preventClose?: boolean;
   setOpen: (open: boolean) => void;
   width?: number;
+  zIndex?: number;
 }

--- a/src/components/dialog/DialogContent.tsx
+++ b/src/components/dialog/DialogContent.tsx
@@ -5,7 +5,11 @@ import { StyledContent, StyledDialogCloseWrapper } from './Dialog.styles';
 import { DialogClose } from './DialogClose';
 import { useDialogContext } from './DialogContext';
 
-export const DialogContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivElement>>((props, propRef) => {
+interface DialogContentProps extends HTMLProps<HTMLDivElement> {
+  zIndex?: number;
+}
+
+export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(({ zIndex = 1000, ...props }, propRef) => {
   const { context: floatingContext, ...context } = useDialogContext();
   const ref = useMergeRefs([context.refs.setFloating, propRef]);
 
@@ -13,13 +17,14 @@ export const DialogContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivElement
 
   return (
     <FloatingPortal>
-      <Overlay lockScroll>
+      <Overlay zIndex={zIndex} lockScroll>
         <FloatingFocusManager context={floatingContext}>
           <StyledContent
             backgroundColor="white.main"
             radius={3}
             $width={context.width}
             ref={ref}
+            $zIndex={zIndex}
             {...context.getFloatingProps(props)}
           >
             {context.hasCloseButton && (

--- a/src/components/dialog/useDialog.ts
+++ b/src/components/dialog/useDialog.ts
@@ -1,13 +1,12 @@
 import { useMemo } from 'react';
-
 import { useClick, useDismiss, useFloating, useInteractions, useRole } from '@floating-ui/react';
-
 import { DialogProps } from './Dialog.types';
 
 export const useDialog = ({
   canEscapeClose = true,
   hasCloseButton = true,
   width = 500,
+  zIndex = 60,
   open,
   preventClose = false,
   setOpen,
@@ -31,9 +30,10 @@ export const useDialog = ({
       width,
       open,
       setOpen,
+      zIndex,
       ...interactions,
       ...data,
     }),
-    [hasCloseButton, width, open, setOpen, interactions, data],
+    [hasCloseButton, width, open, setOpen, zIndex, interactions, data],
   );
 };

--- a/src/components/overlay/Overlay.styles.ts
+++ b/src/components/overlay/Overlay.styles.ts
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 import { FloatingOverlay } from '@floating-ui/react';
 
-export const StyledFloatingOverlay = styled(FloatingOverlay)`
+export const StyledFloatingOverlay = styled(FloatingOverlay)<{ $zIndex: number }>`
   background-color: rgba(16, 22, 26, 0.7);
   display: grid;
   place-items: center;
-  z-index: 60;
+  z-index: ${({ $zIndex }) => $zIndex};
 `;

--- a/src/components/overlay/Overlay.tsx
+++ b/src/components/overlay/Overlay.tsx
@@ -1,6 +1,16 @@
 import { ReactNode } from 'react';
 import { StyledFloatingOverlay } from './Overlay.styles';
 
-export const Overlay = ({ lockScroll, children }: { children?: ReactNode; lockScroll?: boolean | undefined }) => {
-  return <StyledFloatingOverlay lockScroll={lockScroll}>{children}</StyledFloatingOverlay>;
+interface OverlayProps {
+  lockScroll?: boolean;
+  children?: ReactNode;
+  zIndex?: number;
+}
+
+export const Overlay = ({ lockScroll, children, zIndex = 60 }: OverlayProps) => {
+  return (
+    <StyledFloatingOverlay lockScroll={lockScroll} $zIndex={zIndex}>
+      {children}
+    </StyledFloatingOverlay>
+  );
 };


### PR DESCRIPTION
Our Dialog component has 2 problems:

- It does not allow to customize z-index
- It has a discrepancy between de overlay and the content z-index

That provoques cases like this

![image](https://github.com/user-attachments/assets/19469738-ff70-467d-96d3-d6a707227516)
