### PR TITLE
fix: replace wrong type on interface

### DIFF
--- a/src/components/autocomplete/AutoCompleteOptions.tsx
+++ b/src/components/autocomplete/AutoCompleteOptions.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, forwardRef } from 'react';
+import { Fragment, ReactNode, forwardRef } from 'react';
 import { useId } from '@floating-ui/react';
 import { BoxProps } from '../box/Box.types';
 import { Typography } from '../typography';
@@ -27,7 +27,9 @@ const OptionItem = forwardRef<BoxProps, ItemProps & BoxProps>(({ children, activ
         ...rest.style,
       }}
     >
-      <Typography variant="text14">{children}</Typography>
+      <Typography variant="text14" as="div">
+        {children}
+      </Typography>
     </StyledOption>
   );
 });
@@ -57,7 +59,7 @@ export const AutoCompleteOptions = ({
     <>
       {items.map((item, index) =>
         item.type === 'separator' ? (
-          <>{item.children}</>
+          <Fragment key={`key_separator_${index}`}>{item.children}</Fragment>
         ) : (
           <OptionItem
             key={item.id}

--- a/src/components/autocomplete/Autocomplete.tsx
+++ b/src/components/autocomplete/Autocomplete.tsx
@@ -15,7 +15,7 @@ import { Box } from '../box';
 import { TextField } from '../text-field';
 import { Typography } from '../typography';
 import { AutoCompleteOptions } from './AutoCompleteOptions';
-import { AutoCompleteItem, AutocompleteProps } from './Autocomplete.types';
+import { AutoCompleteItemOption, AutocompleteProps } from './Autocomplete.types';
 
 export const Autocomplete = ({
   endAdornment,
@@ -79,7 +79,7 @@ export const Autocomplete = ({
     setOpen(true);
   };
 
-  const handleSelectItem = (item: AutoCompleteItem) => {
+  const handleSelectItem = (item: AutoCompleteItemOption) => {
     onSelectItem(item);
     setActiveIndex(null);
     setOpen(false);
@@ -98,7 +98,12 @@ export const Autocomplete = ({
             placeholder,
             'aria-autocomplete': 'list',
             onKeyDown(event) {
-              if (event.key === 'Enter' && activeIndex != null && items[activeIndex]) {
+              if (
+                event.key === 'Enter' &&
+                activeIndex != null &&
+                items[activeIndex] &&
+                items[activeIndex].type !== 'separator'
+              ) {
                 handleSelectItem(items[activeIndex]);
               }
             },

--- a/src/components/autocomplete/Autocomplete.types.ts
+++ b/src/components/autocomplete/Autocomplete.types.ts
@@ -17,12 +17,12 @@ export type AutoCompleteItem = AutoCompleteItemOption | AutoCompleteItemSeparato
 
 export interface AutocompleteProps {
   items: AutoCompleteItem[];
-  selectedItemId?: AutoCompleteItem['id'];
+  selectedItemId?: AutoCompleteItemOption['id'];
   placeholder?: string;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;
   inputValue?: string;
   onChange: NonNullable<TextFieldProps['onChange']>;
-  onSelectItem: (item: AutoCompleteItem) => void;
+  onSelectItem: (item: AutoCompleteItemOption) => void;
   itemRenderer?: (item: AutoCompleteItemOption) => ReactNode;
 }


### PR DESCRIPTION
Fixes a wrong type from the yesterday PR. 
`AutoCompleteItem` also includes the separator, which cannot be selected.