### PR TITLE
fix: prevent key property to be provided as spread

### DIFF
--- a/src/components/autocomplete/AutoCompleteOptions.tsx
+++ b/src/components/autocomplete/AutoCompleteOptions.tsx
@@ -10,29 +10,32 @@ interface ItemProps {
   active: boolean;
 }
 
-const OptionItem = forwardRef<BoxProps, ItemProps & BoxProps>(({ children, active, ...rest }, ref) => {
-  const id = useId();
+const OptionItem = forwardRef<BoxProps, ItemProps & BoxProps & { key?: string }>(
+  ({ children, active, key, ...rest }, ref) => {
+    const id = useId();
 
-  return (
-    <StyledOption
-      p={1}
-      radius={1}
-      backgroundColor={active ? 'blue.100' : undefined}
-      ref={ref}
-      role="option"
-      id={id}
-      aria-selected={active}
-      {...rest}
-      style={{
-        ...rest.style,
-      }}
-    >
-      <Typography variant="text14" as="div">
-        {children}
-      </Typography>
-    </StyledOption>
-  );
-});
+    return (
+      <StyledOption
+        key={key}
+        p={1}
+        radius={1}
+        backgroundColor={active ? 'blue.100' : undefined}
+        ref={ref}
+        role="option"
+        id={id}
+        aria-selected={active}
+        {...rest}
+        style={{
+          ...rest.style,
+        }}
+      >
+        <Typography variant="text14" as="div">
+          {children}
+        </Typography>
+      </StyledOption>
+    );
+  },
+);
 
 OptionItem.displayName = 'OptionItemAutocomplete';
 


### PR DESCRIPTION
Small PR to try to prevent the next warning:

![image](https://github.com/user-attachments/assets/27b426db-7fd7-494f-83be-1d89dcd1f80a)
