### PR TITLE
fix: allow to customize autocomplete placement

### DIFF
--- a/src/components/autocomplete/AutoCompleteOptions.tsx
+++ b/src/components/autocomplete/AutoCompleteOptions.tsx
@@ -10,32 +10,29 @@ interface ItemProps {
   active: boolean;
 }
 
-const OptionItem = forwardRef<BoxProps, ItemProps & BoxProps & { key?: string }>(
-  ({ children, active, key, ...rest }, ref) => {
-    const id = useId();
+const OptionItem = forwardRef<BoxProps, ItemProps & BoxProps>(({ children, active, ...rest }, ref) => {
+  const id = useId();
 
-    return (
-      <StyledOption
-        key={key}
-        p={1}
-        radius={1}
-        backgroundColor={active ? 'blue.100' : undefined}
-        ref={ref}
-        role="option"
-        id={id}
-        aria-selected={active}
-        {...rest}
-        style={{
-          ...rest.style,
-        }}
-      >
-        <Typography variant="text14" as="div">
-          {children}
-        </Typography>
-      </StyledOption>
-    );
-  },
-);
+  return (
+    <StyledOption
+      p={1}
+      radius={1}
+      backgroundColor={active ? 'blue.100' : undefined}
+      ref={ref}
+      role="option"
+      id={id}
+      aria-selected={active}
+      {...rest}
+      style={{
+        ...rest.style,
+      }}
+    >
+      <Typography variant="text14" as="div">
+        {children}
+      </Typography>
+    </StyledOption>
+  );
+});
 
 OptionItem.displayName = 'OptionItemAutocomplete';
 
@@ -67,7 +64,6 @@ export const AutoCompleteOptions = ({
           <OptionItem
             key={item.id}
             {...getItemProps({
-              key: item.id,
               ref(node) {
                 listRef.current[index] = node;
               },

--- a/src/components/autocomplete/Autocomplete.tsx
+++ b/src/components/autocomplete/Autocomplete.tsx
@@ -24,6 +24,7 @@ export const Autocomplete = ({
   placeholder,
   startAdornment,
   selectedItemId,
+  placement = 'bottom',
   onChange,
   onSelectItem,
   itemRenderer,
@@ -34,6 +35,7 @@ export const Autocomplete = ({
   const listRef = useRef<Array<HTMLElement | null>>([]);
 
   const { refs, floatingStyles, context } = useFloating<HTMLInputElement>({
+    placement,
     whileElementsMounted: autoUpdate,
     open,
     onOpenChange: setOpen,

--- a/src/components/autocomplete/Autocomplete.types.ts
+++ b/src/components/autocomplete/Autocomplete.types.ts
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { Placement } from '@floating-ui/react';
 import { TextFieldProps } from '../text-field/TextField.types';
 
 export type AutoCompleteItemSeparator = {
@@ -22,6 +23,7 @@ export interface AutocompleteProps {
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;
   inputValue?: string;
+  placement?: Placement;
   onChange: NonNullable<TextFieldProps['onChange']>;
   onSelectItem: (item: AutoCompleteItemOption) => void;
   itemRenderer?: (item: AutoCompleteItemOption) => ReactNode;


### PR DESCRIPTION
Allows to customize placement on autocomplete, like on tooltips and popovers.

Also we need a new try to prevent the new error about key. React won't pass `key` to the children, so there is no need, to specify it.

![image](https://github.com/user-attachments/assets/ecd206ea-f706-4410-afe6-d21521dd9b7f)
