### PR TITLE
fix: select item with higher priority event

### DIFF
--- a/src/components/autocomplete/AutoCompleteOptions.tsx
+++ b/src/components/autocomplete/AutoCompleteOptions.tsx
@@ -67,7 +67,7 @@ export const AutoCompleteOptions = ({
               ref(node) {
                 listRef.current[index] = node;
               },
-              onClick() {
+              onMouseDown() {
                 handleSelectItem(item);
                 refs.domReference.current?.focus();
               },

--- a/src/components/autocomplete/Autocomplete.tsx
+++ b/src/components/autocomplete/Autocomplete.tsx
@@ -26,6 +26,7 @@ export const Autocomplete = ({
   selectedItemId,
   placement = 'bottom',
   prenventCloseOnEmptySearch,
+  onFocus,
   onBlur,
   onChange,
   onSelectItem,
@@ -96,6 +97,7 @@ export const Autocomplete = ({
           startAdornment={startAdornment}
           endAdornment={endAdornment}
           {...getReferenceProps({
+            onFocus,
             onBlur,
             onChange: handleChangeInput,
             value: inputValue,

--- a/src/components/autocomplete/Autocomplete.types.ts
+++ b/src/components/autocomplete/Autocomplete.types.ts
@@ -25,6 +25,7 @@ export interface AutocompleteProps {
   inputValue?: string;
   placement?: Placement;
   prenventCloseOnEmptySearch?: boolean;
+  onFocus?: TextFieldProps['onFocus'];
   onBlur?: TextFieldProps['onBlur'];
   onChange: NonNullable<TextFieldProps['onChange']>;
   onSelectItem: (item: AutoCompleteItemOption) => void;


### PR DESCRIPTION
Previous change added the posibility to use `onBlur` when input loses the focus. However, selecting an element should not trigger onblur or at provide a way for the consumer to decide what need to execute first.

With this PR we reorder the selecting event to `mouseDown` which has a greater priority than `onBlur` and we allow to handle `onFocus` too