### PR TITLE
feat: allow custom render for no results on autocomplete

### DIFF
--- a/src/components/autocomplete/Autocomplete.stories.tsx
+++ b/src/components/autocomplete/Autocomplete.stories.tsx
@@ -57,6 +57,23 @@ export const NoResults: Story = {
   },
 };
 
+export const NoResultsCustom: Story = {
+  args: {
+    items: [],
+    noResults: (
+      <Box display="flex" flexDirection="column" alignItems="center" gap={1}>
+        <Typography variant="text14" color="error.light">
+          THERE IS
+        </Typography>
+        <Divider />
+        <Typography variant="h3" color="error.dark">
+          -- NO RESULTS --
+        </Typography>
+      </Box>
+    ),
+  },
+};
+
 export const PreventClose: Story = {
   args: {
     items: [

--- a/src/components/autocomplete/Autocomplete.test.tsx
+++ b/src/components/autocomplete/Autocomplete.test.tsx
@@ -116,5 +116,17 @@ describe('Autocomplete', () => {
 
       expect(onSelectItem).toHaveBeenCalledWith(selectOption);
     });
+
+    it('allows to customize render on no results', async () => {
+      const { user } = renderComponent({
+        placeholder: 'Write something here',
+        items: [],
+        noResults: <div>CUSTOM RENDER</div>,
+      });
+
+      await user.type(screen.getByPlaceholderText('Write something here'), '1');
+
+      expect(screen.getByText('CUSTOM RENDER')).toBeVisible();
+    });
   });
 });

--- a/src/components/autocomplete/Autocomplete.tsx
+++ b/src/components/autocomplete/Autocomplete.tsx
@@ -13,9 +13,9 @@ import {
 } from '@floating-ui/react';
 import { Box } from '../box';
 import { TextField } from '../text-field';
-import { Typography } from '../typography';
 import { AutoCompleteOptions } from './AutoCompleteOptions';
 import { AutoCompleteItemOption, AutocompleteProps } from './Autocomplete.types';
+import { AutocompleteNoResults } from './AutocompleteNoResults';
 
 export const Autocomplete = ({
   endAdornment,
@@ -26,6 +26,7 @@ export const Autocomplete = ({
   selectedItemId,
   placement = 'bottom',
   prenventCloseOnEmptySearch,
+  noResults,
   onFocus,
   onBlur,
   onChange,
@@ -143,9 +144,7 @@ export const Autocomplete = ({
                     itemRenderer={itemRenderer}
                   />
                 ) : (
-                  <Typography variant="text12" color="neutral.400" p={1}>
-                    NO RESULTS...
-                  </Typography>
+                  <AutocompleteNoResults>{noResults}</AutocompleteNoResults>
                 )}
               </Box>
             </div>

--- a/src/components/autocomplete/Autocomplete.types.ts
+++ b/src/components/autocomplete/Autocomplete.types.ts
@@ -25,6 +25,7 @@ export interface AutocompleteProps {
   inputValue?: string;
   placement?: Placement;
   prenventCloseOnEmptySearch?: boolean;
+  noResults?: ReactNode;
   onFocus?: TextFieldProps['onFocus'];
   onBlur?: TextFieldProps['onBlur'];
   onChange: NonNullable<TextFieldProps['onChange']>;

--- a/src/components/autocomplete/AutocompleteNoResults.tsx
+++ b/src/components/autocomplete/AutocompleteNoResults.tsx
@@ -1,0 +1,15 @@
+import { Typography } from '../typography';
+
+interface AutocompleteNoResultsProps {
+  children?: React.ReactNode;
+}
+
+export const AutocompleteNoResults = ({ children }: AutocompleteNoResultsProps) => {
+  if (children) return <>{children}</>;
+
+  return (
+    <Typography variant="text12" color="neutral.400" p={1}>
+      NO RESULTS...
+    </Typography>
+  );
+};


### PR DESCRIPTION
Allows to customize the render for no results on autocomplete component.

![image](https://github.com/user-attachments/assets/78ed9106-7b39-407a-8c69-4b54250ffb94)
