### PR TITLE
fix: disabled color on error button variant

### DIFF
--- a/src/components/button/Button.utils.ts
+++ b/src/components/button/Button.utils.ts
@@ -86,6 +86,7 @@ export const getTypographyColorDefault = (
   }
 
   if (disabled) {
+    if (color === 'error.main') return theme.palette.error.light;
     return theme.palette.neutral[300];
   }
 


### PR DESCRIPTION
Fixes disabled color for error variant on buttons.

[Figma](https://www.figma.com/design/04e06uzVIOJzrIBpbcOquL/LUI-Design-System?node-id=886-412&node-type=frame&t=B4zDGD4ImI2SUoUH-0)

![image](https://github.com/user-attachments/assets/9b1d593f-0305-49ba-85f5-25ff9ca1be18)
