### PR TITLE
fix: typescript missing value

### DIFF
--- a/src/shared/theme.types.ts
+++ b/src/shared/theme.types.ts
@@ -54,6 +54,7 @@ export interface Theme {
     };
     orange: {
       main: string;
+      100: string;
       200: string;
       400: string;
       600: string;


### PR DESCRIPTION
Color is defined, but TS don't.


<img width="203" alt="image" src="https://github.com/user-attachments/assets/dc103928-3dc6-4563-926c-3edc3e49ec18">
