### PR TITLE
MAN-1433: Match shadow from level 2 to the figma shadow values 

### DIFF
--- a/src/components/box/Box.constants.ts
+++ b/src/components/box/Box.constants.ts
@@ -3,7 +3,7 @@ import { ElevationType, RadiusType } from './Box.types';
 export const BOX_SHADOW_MAPPING: Record<ElevationType, string> = {
   0: 'none',
   1: '0px 1px 1px rgba(0, 0, 0, 0.08), 0px 2px 2px 1px rgba(0, 0, 0, 0.08)',
-  2: '0px 2px 2px rgba(0, 0, 0, 0.08), 0px 4px 4px rgba(0, 0, 0, 0.08), 0px 8px 8px rgba(0, 0, 0, 0.04)',
+  2: '0px 2px 2px 0px rgba(0, 0, 0, 0.08), 0px 4px 4px 0px rgba(0, 0, 0, 0.08), 0px 8px 8px 0px rgba(0, 0, 0, 0.04)',
   3: '0px 4px 4px rgba(0, 0, 0, 0.04), 0px 8px 8px rgba(0, 0, 0, 0.06), 0px 16px 16px rgba(0, 0, 0, 0.08)',
   4: '0px 4px 4px rgba(0, 0, 0, 0.04), 0px 8px 8px rgba(0, 0, 0, 0.08), 0px 16px 16px rgba(0, 0, 0, 0.08), 0px 32px 32px rgba(0, 0, 0, 0.08)',
 };


### PR DESCRIPTION
Ila notice that the shadows used on the level 2 of elevation doesn't match with the figma.