### PR TITLE
MAN-1294: Allow pass aria-labelledby to have better test selector and a11y

### DIFF
--- a/src/components/autocomplete/Autocomplete.test.tsx
+++ b/src/components/autocomplete/Autocomplete.test.tsx
@@ -18,6 +18,21 @@ describe('Autocomplete', () => {
     mockResizeObserver();
   });
 
+  it('when aria-labelledby is passed, should be selected by the content of aria-labelledby', () => {
+    render(
+      <>
+        <span id="label">Span Text</span>
+        <Autocomplete items={[]} onChange={jest.fn()} onSelectItem={jest.fn()} aria-labelledby="label" />
+      </>,
+    );
+
+    expect(
+      screen.getByRole('combobox', {
+        name: 'Span Text',
+      }),
+    ).toHaveAttribute('aria-labelledby', 'label');
+  });
+
   it('should render input with placeholder', () => {
     renderComponent({ placeholder: 'Write something here' });
 

--- a/src/components/autocomplete/Autocomplete.tsx
+++ b/src/components/autocomplete/Autocomplete.tsx
@@ -36,6 +36,7 @@ export const Autocomplete = ({
   onSelectItem,
   itemRenderer,
   disabled,
+  'aria-labelledby': arialLabelledBy,
 }: AutocompleteProps) => {
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
@@ -112,6 +113,7 @@ export const Autocomplete = ({
             ref: refs.setReference,
             placeholder,
             'aria-autocomplete': 'list',
+            'aria-labelledby': arialLabelledBy,
             onKeyDown(event) {
               if (
                 event.key === 'Enter' &&

--- a/src/components/autocomplete/Autocomplete.types.ts
+++ b/src/components/autocomplete/Autocomplete.types.ts
@@ -41,4 +41,5 @@ export interface AutocompleteProps {
     option?: CSSProperties;
     optionHover?: CSSProperties;
   };
+  'aria-labelledby'?: string;
 }


### PR DESCRIPTION
I need to easy click between a group of combobox, like the following image:

<img width="235" alt="image" src="https://github.com/user-attachments/assets/57645186-4198-40a0-aa90-a0bceeaf2132" />

The current implementation doesn't allow me create specific label, and all the combobox have the same placeholder. On top of that, the select doesn't have a label so the text is going go be hidden visually. Adding this aria give us two benefits

- Tests: I don't need to create a specific HTML selector to click a specific combobox.
- A11y: As a side effect the selects have a semantic view for screen readers.