### PR TITLE
feat: improve typechecking when using as

### DIFF
--- a/src/components/typography/Typography.tsx
+++ b/src/components/typography/Typography.tsx
@@ -1,8 +1,9 @@
+import { ElementType } from 'react';
 import { VARIANT_MAPPING } from './Typography.constants';
 import { BaseTypography } from './Typography.styles';
 import { TypographyProps } from './Typography.types';
 
-export const Typography = ({
+export const Typography = <TAs extends ElementType = 'p'>({
   as,
   children,
   color,
@@ -10,7 +11,7 @@ export const Typography = ({
   fontWeight,
   variant = 'text16',
   ...rest
-}: TypographyProps) => {
+}: TypographyProps<TAs>) => {
   return (
     <BaseTypography
       as={as || VARIANT_MAPPING[variant]}

--- a/src/components/typography/Typography.types.ts
+++ b/src/components/typography/Typography.types.ts
@@ -1,4 +1,4 @@
-import { ElementType, HTMLAttributes, ReactNode } from 'react';
+import { ElementType, ReactNode } from 'react';
 import { ColorsTypes } from '../../shared/theme.types';
 import { BaseSpacingProps } from '../base-spacing';
 
@@ -18,14 +18,15 @@ export type TypographyVariants =
 
 export type FontWeightVariants = 400 | 500 | 700;
 
-export interface TypographyProps extends BaseSpacingProps, HTMLAttributes<HTMLParagraphElement> {
-  as?: ElementType | keyof JSX.IntrinsicElements;
+export type TypographyProps<TAs extends ElementType = 'p'> = {
+  as?: TAs;
   children?: ReactNode;
   color?: ColorsTypes;
   fontWeight?: FontWeightVariants;
   ellipsize?: boolean;
   variant?: TypographyVariants;
-}
+} & BaseSpacingProps &
+  React.ComponentPropsWithoutRef<TAs>;
 
 export interface TypographyStyledProps {
   $color: TypographyProps['color'];


### PR DESCRIPTION
Types for  `<Typography>` are coupled to `<p>` elements. When using it as a different element makes TS complain. Screenshot from landbot:

![image](https://github.com/user-attachments/assets/e88a9f3d-2130-4f48-9fba-3746e8f0a768)


With this PR we improve typing to pick the HTML props for the `as` element used.

<img width="950" alt="Captura de pantalla 2025-03-27 a las 9 29 33" src="https://github.com/user-attachments/assets/70bc546d-832b-498c-861c-c0656e81228c" />
