### PR TITLE
feat: allow to customize skeleton sizes on table component

### DIFF
--- a/src/components/table/Table.BodySkeleton.tsx
+++ b/src/components/table/Table.BodySkeleton.tsx
@@ -12,9 +12,10 @@ export interface TableBodySkeletonProps {
   columns: number;
   showIndex?: boolean;
   longCellsPositions?: number[];
+  sizes?: number[];
 }
 
-export const TableBodySkeleton = ({ rows, columns, showIndex, longCellsPositions }: TableBodySkeletonProps) => {
+export const TableBodySkeleton = ({ rows, columns, showIndex, longCellsPositions, sizes }: TableBodySkeletonProps) => {
   return (
     <StyledSkeletonBody>
       {Array.from({ length: rows }).map((_, rowIndex) => (
@@ -29,6 +30,7 @@ export const TableBodySkeleton = ({ rows, columns, showIndex, longCellsPositions
               key={colIndex}
               flexGrow={longCellsPositions?.includes(colIndex) ? 1 : undefined}
               aria-label={`Loading cell ${rowIndex}-${colIndex}`}
+              $width={sizes?.[colIndex]}
             >
               <StyledSkeletonCellContent />
             </StyledSkeletonCell>

--- a/src/components/table/Table.stories.tsx
+++ b/src/components/table/Table.stories.tsx
@@ -120,6 +120,15 @@ export const Interactive: Story = {
 
 export const Loading: Story = {
   render: function Render() {
+    const headers = [
+      'Person',
+      'Most interest in',
+      'Age',
+      'long long long long long long long long long long long long text',
+    ];
+
+    const sizes = [400, 100, 500, 200];
+
     return (
       <Table>
         <TableHeader index>
@@ -131,7 +140,13 @@ export const Loading: Story = {
             );
           })}
         </TableHeader>
-        <TableBodySkeleton rows={data.length} columns={headers.length} longCellsPositions={[3]} showIndex />
+        <TableBodySkeleton
+          rows={data.length}
+          columns={headers.length}
+          longCellsPositions={[3]}
+          sizes={sizes}
+          showIndex
+        />
       </Table>
     );
   },


### PR DESCRIPTION
Allows to customize skeleton cell size in the same way we do with regular rows.

![image](https://github.com/user-attachments/assets/09c9813e-ef37-41ee-8f8d-bcc1442974e7)
