### PR TITLE
feat: Set but default a 0 border for popover content while allowing to set it in case it's needed it

### DIFF
--- a/src/components/popover/Popover.types.ts
+++ b/src/components/popover/Popover.types.ts
@@ -27,5 +27,5 @@ export interface PopoverContentProps {
   children?: ReactNode;
   id?: string;
   root?: HTMLElement | null | MutableRefObject<HTMLElement | null>;
-  border?: BorderType | null;
+  border?: BorderType;
 }

--- a/src/components/popover/Popover.types.ts
+++ b/src/components/popover/Popover.types.ts
@@ -1,5 +1,6 @@
 import { MutableRefObject, ReactNode } from 'react';
 import { Placement } from '@floating-ui/react';
+import { BorderType } from '../box';
 
 export interface PopoverProps {
   canEscapeClose?: boolean;
@@ -26,4 +27,5 @@ export interface PopoverContentProps {
   children?: ReactNode;
   id?: string;
   root?: HTMLElement | null | MutableRefObject<HTMLElement | null>;
+  border?: BorderType | null;
 }

--- a/src/components/popover/PopoverContent.tsx
+++ b/src/components/popover/PopoverContent.tsx
@@ -17,7 +17,7 @@ export const PopoverContent = (props: HTMLProps<HTMLDivElement> & PopoverContent
       <FloatingFocusManager context={floatingContext}>
         <StyledPopoverContent
           $color={context.color}
-          border={1}
+          border={props.border ?? 0}
           radius={2}
           elevation={2}
           ref={context.refs.setFloating}

--- a/src/components/popover/PopoverContent.tsx
+++ b/src/components/popover/PopoverContent.tsx
@@ -17,7 +17,7 @@ export const PopoverContent = (props: HTMLProps<HTMLDivElement> & PopoverContent
       <FloatingFocusManager context={floatingContext}>
         <StyledPopoverContent
           $color={context.color}
-          border={props.border ?? 0}
+          border={props.border}
           radius={2}
           elevation={2}
           ref={context.refs.setFloating}


### PR DESCRIPTION
When we use Popover in conjuction with Menu a double border appears. This PR remove the border that have by default PopoverContent. For the situation this doesn't apply you can set a border value