### PR TITLE
feat(Button): Set 'button' as default button type

### DIFF
--- a/src/components/button/Button.test.tsx
+++ b/src/components/button/Button.test.tsx
@@ -92,4 +92,12 @@ describe('Button', () => {
     const { container } = render(<Button startIcon={<Robot />} />);
     expect(container.querySelector('svg')).toBeInTheDocument();
   });
+  it('sets default type to button', () => {
+    const { getByRole } = render(<Button>test</Button>);
+    expect(getByRole('button')).toHaveAttribute('type', 'button');
+  });
+  it.each(['submit', 'reset', 'button'])('sets type to %s', (type) => {
+    const { getByRole } = render(<Button type={type}>test</Button>);
+    expect(getByRole('button')).toHaveAttribute('type', type);
+  });
 });

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -23,6 +23,7 @@ export const Button = forwardRef<HTMLElement, ButtonProps>(
       onClick,
       textAlign = 'center',
       ellipsize,
+      type = 'button',
       ...rest
     },
     ref,
@@ -48,6 +49,7 @@ export const Button = forwardRef<HTMLElement, ButtonProps>(
         disabled={disabled || isLoading}
         href={href}
         onClick={onClick}
+        type={type}
         {...rest}
         ref={ref}
       >


### PR DESCRIPTION
The standard is 'submit', but it's counterintuitive.

https://www.w3schools.com/jsref/prop_pushbutton_type.asp