### PR TITLE
fix: remove key attribute beign spread

### DIFF
--- a/src/components/select/Select.test.tsx
+++ b/src/components/select/Select.test.tsx
@@ -17,7 +17,7 @@ describe('Select', () => {
     mockResizeObserver();
   });
 
-  it('should render with label', async () => {
+  it('should render with label', () => {
     renderComponent({
       label: 'Select one',
     });

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -141,7 +141,6 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
                         <SelectItem
                           key={item.value}
                           {...getItemProps({
-                            key: item.value,
                             ref(node) {
                               listRef.current[index] = node;
                             },


### PR DESCRIPTION
Remove key property being spread into floating-ui property rather than on the element directly on select component. This fix was already applied on other Dialog, Popover and Autocomplete component, but Select was missing.

Also it prrevents next warnings on tests:

![Captura de pantalla 2025-07-02 a las 11 01 51](https://github.com/user-attachments/assets/9f58a215-e9b6-4fd6-a71e-8e435724996d)


