### PR TITLE
feat: accessibility and inputs improvements

### DIFF
--- a/src/components/autocomplete/Autocomplete.stories.tsx
+++ b/src/components/autocomplete/Autocomplete.stories.tsx
@@ -152,3 +152,20 @@ export const CustomRender: Story = {
     },
   },
 };
+
+export const Labeled: Story = {
+  args: {
+    label: 'Label',
+    description: 'Description',
+    helperText: 'Helper text',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    error: true,
+    label: 'Label',
+    description: 'Description',
+    helperText: 'Helper text',
+  },
+};

--- a/src/components/autocomplete/Autocomplete.test.tsx
+++ b/src/components/autocomplete/Autocomplete.test.tsx
@@ -120,6 +120,24 @@ describe('Autocomplete', () => {
     expect(screen.queryByRole('option', { name: 'Option 1' })).not.toBeInTheDocument();
   });
 
+  it('should render label', () => {
+    renderComponent({ label: 'Label' });
+
+    expect(screen.getByLabelText('Label')).toBeVisible();
+  });
+
+  it('should render description', () => {
+    renderComponent({ description: 'Description' });
+
+    expect(screen.getByLabelText('Description')).toBeVisible();
+  });
+
+  it('should render helper text', () => {
+    renderComponent({ helperText: 'Helper text' });
+
+    expect(screen.getByText('Helper text')).toBeVisible();
+  });
+
   describe('Custom render', () => {
     it('should render items when start typing', async () => {
       const { user } = renderComponent({

--- a/src/components/autocomplete/Autocomplete.tsx
+++ b/src/components/autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useRef, useState } from 'react';
+import { ChangeEvent, useId, useRef, useState } from 'react';
 import {
   FloatingFocusManager,
   FloatingPortal,
@@ -12,15 +12,23 @@ import {
   useRole,
 } from '@floating-ui/react';
 import { Box } from '../box';
+import { FormHelperText } from '../form-helper-text';
+import { FormLabel } from '../form-label';
 import { TextField } from '../text-field';
+import { Typography } from '../typography';
 import { AutoCompleteOptions } from './AutoCompleteOptions';
 import { AutoCompleteItemOption, AutocompleteProps } from './Autocomplete.types';
 import { AutocompleteNoResults } from './AutocompleteNoResults';
 
 export const Autocomplete = ({
   endAdornment,
+  error,
   inputValue,
   items,
+  label,
+  description,
+  id,
+  helperText,
   placeholder,
   startAdornment,
   selectedItemId,
@@ -40,6 +48,7 @@ export const Autocomplete = ({
 }: AutocompleteProps) => {
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const autoId = useId();
 
   const listRef = useRef<Array<HTMLElement | null>>([]);
 
@@ -101,7 +110,19 @@ export const Autocomplete = ({
   return (
     <>
       <div onMouseDown={handleFocusInput}>
+        {(label || description) && (
+          <FormLabel htmlFor={id ?? autoId}>
+            {label && (
+              <Typography variant="text14" fontWeight={700}>
+                {label}
+              </Typography>
+            )}
+            {description && <Typography variant="text14">{description}</Typography>}
+          </FormLabel>
+        )}
         <TextField
+          id={id ?? autoId}
+          error={error}
           disabled={disabled}
           startAdornment={startAdornment}
           endAdornment={endAdornment}
@@ -128,6 +149,11 @@ export const Autocomplete = ({
           })}
         />
       </div>
+      {helperText && (
+        <FormHelperText variant="text12" color={error ? 'error.main' : 'neutral.main'}>
+          {helperText}
+        </FormHelperText>
+      )}
       <FloatingPortal>
         {showPopover && (
           <FloatingFocusManager context={context} visuallyHiddenDismiss initialFocus={-1}>

--- a/src/components/autocomplete/Autocomplete.types.ts
+++ b/src/components/autocomplete/Autocomplete.types.ts
@@ -17,6 +17,11 @@ export type AutoCompleteItemOption = {
 export type AutoCompleteItem = AutoCompleteItemOption | AutoCompleteItemSeparator;
 
 export interface AutocompleteProps {
+  error?: boolean;
+  label?: string;
+  id?: string;
+  description?: string;
+  helperText?: string | null;
   items: AutoCompleteItem[];
   selectedItemId?: AutoCompleteItemOption['id'];
   placeholder?: string;

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -9,5 +9,9 @@ interface MenuProps {
 }
 
 export const Menu = ({ children, styles }: MenuProps) => {
-  return <StyledContainer style={styles?.container}>{children}</StyledContainer>;
+  return (
+    <StyledContainer role="menu" style={styles?.container}>
+      {children}
+    </StyledContainer>
+  );
 };

--- a/src/components/menu/MenuButton.tsx
+++ b/src/components/menu/MenuButton.tsx
@@ -3,6 +3,6 @@ import { Button, ButtonProps } from '../button';
 
 export const MenuButton = forwardRef<HTMLElement, ButtonProps>(
   ({ color = 'blue.main', textAlign = 'left', variant: _, ...props }, ref) => {
-    return <Button ref={ref} variant="menu-item" textAlign={textAlign} color={color} {...props} />;
+    return <Button ref={ref} variant="menu-item" textAlign={textAlign} color={color} role="menuitem" {...props} />;
   },
 );

--- a/src/components/text-area/TextArea.tsx
+++ b/src/components/text-area/TextArea.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, useId } from 'react';
 import { Box } from '../box';
 import { FormHelperText } from '../form-helper-text';
 import { FormLabel } from '../form-label';
@@ -7,35 +7,39 @@ import { StyledTextArea } from './TextArea.styles';
 import { TextAreaProps } from './TextArea.types';
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ description, disabled, error, helperText, id, label, fullHeight, resize = 'none', ...rest }, ref) => (
-    <Box display="flex" flexDirection="column" flexGrow={fullHeight ? 1 : undefined}>
-      {(label || description) && (
-        <FormLabel htmlFor={id}>
-          {label && (
-            <Typography variant="text14" fontWeight={700}>
-              {label}
-            </Typography>
-          )}
-          {description && <Typography variant="text14">{description}</Typography>}
-        </FormLabel>
-      )}
-      <Box display="flex" flexGrow={fullHeight ? 1 : undefined}>
-        <StyledTextArea
-          {...rest}
-          disabled={disabled}
-          $disabled={disabled}
-          $error={error}
-          id={id}
-          ref={ref}
-          $resize={resize}
-        />
+  ({ description, disabled, error, helperText, id, label, fullHeight, resize = 'none', ...rest }, ref) => {
+    const autoId = useId();
+
+    return (
+      <Box display="flex" flexDirection="column" flexGrow={fullHeight ? 1 : undefined}>
+        {(label || description) && (
+          <FormLabel htmlFor={id ?? autoId}>
+            {label && (
+              <Typography variant="text14" fontWeight={700}>
+                {label}
+              </Typography>
+            )}
+            {description && <Typography variant="text14">{description}</Typography>}
+          </FormLabel>
+        )}
+        <Box display="flex" flexGrow={fullHeight ? 1 : undefined}>
+          <StyledTextArea
+            {...rest}
+            disabled={disabled}
+            $disabled={disabled}
+            $error={error}
+            id={id ?? autoId}
+            ref={ref}
+            $resize={resize}
+          />
+        </Box>
+        {helperText && (
+          <FormHelperText variant="text12" color={error ? 'error.main' : 'neutral.main'}>
+            {helperText}
+          </FormHelperText>
+        )}
       </Box>
-      {helperText && (
-        <FormHelperText variant="text12" color={error ? 'error.main' : 'neutral.main'}>
-          {helperText}
-        </FormHelperText>
-      )}
-    </Box>
-  ),
+    );
+  },
 );
 TextArea.displayName = 'TextArea';


### PR DESCRIPTION
Added some improvements for components:

### Menu
* Set role `menu` for better accessibility.

### MenuButton
* Set role `menuitem` for better accessibility.

### TextArea
* Uses automatic id if not provided for better accessibility.

### Autocomplete
* Added props `label`, `description`, `error` and `helperText` to unify input groups layouts.