### PR TITLE
TT-1078: remove menu inner padding, border and shadow

### DIFF
--- a/src/components/menu/Menu.stories.tsx
+++ b/src/components/menu/Menu.stories.tsx
@@ -33,3 +33,9 @@ export default meta;
 type Story = StoryObj<typeof Menu>;
 
 export const Default: Story = {};
+
+export const CustomWidth: Story = {
+  args: {
+    width: '100%',
+  },
+};

--- a/src/components/menu/Menu.styles.ts
+++ b/src/components/menu/Menu.styles.ts
@@ -7,6 +7,6 @@ export const StyledContainer = styled(Box).attrs({
   display: 'flex',
   flexDirection: 'column',
   gap: 4,
-})`
-  width: fit-content;
+})<{ $width?: string | number }>`
+  width: ${({ $width }) => (typeof $width === 'number' ? `${$width}px` : $width)};
 `;

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -1,6 +1,11 @@
+import { CSSProperties } from 'react';
 import { BoxProps } from '../box';
 import { StyledContainer } from './Menu.styles';
 
-export const Menu = (props: BoxProps) => {
-  return <StyledContainer role="menu" {...props} />;
+interface MenuProps extends BoxProps {
+  width?: CSSProperties['width'];
+}
+
+export const Menu = ({ width = 200, ...props }: MenuProps) => {
+  return <StyledContainer role="menu" $width={width} {...props} />;
 };


### PR DESCRIPTION
Removed border, shadow, and padding from the Menu component, delegating these styles to its wrapper component (typically PopoverContent).

As the prop `styles.container` is removed, I'll change its usage in the frontend