### PR TITLE
feat: update popovercontent border color

### DIFF
--- a/src/components/menu/Menu.styles.ts
+++ b/src/components/menu/Menu.styles.ts
@@ -2,8 +2,6 @@ import { styled } from 'styled-components';
 import { Box } from '../box';
 
 export const StyledContainer = styled(Box).attrs({
-  backgroundColor: 'white.main',
-  radius: 1,
   display: 'flex',
   flexDirection: 'column',
   gap: 4,

--- a/src/components/popover/Popover.styles.tsx
+++ b/src/components/popover/Popover.styles.tsx
@@ -8,7 +8,7 @@ export const StyledPopoverContent = styled(Box)<{ $color?: 'blue' | 'white' }>`
   max-width: ${pxToRem(284)}rem;
   outline: none;
   background-color: ${({ $color, theme }) => ($color === 'blue' ? theme.palette.blue[800] : theme.palette.white.main)};
-  border: 1px solid ${({ $color, theme }) => ($color === 'blue' ? theme.palette.blue[800] : theme.palette.neutral[300])};
+  border: 1px solid ${({ $color, theme }) => ($color === 'blue' ? theme.palette.blue[800] : theme.palette.neutral[200])};
   color: ${({ $color, theme }) => ($color === 'blue' ? theme.palette.white.main : theme.palette.blue.main)};
 `;
 

--- a/src/components/popover/PopoverContent.tsx
+++ b/src/components/popover/PopoverContent.tsx
@@ -40,7 +40,7 @@ export const PopoverContent = (props: HTMLProps<HTMLDivElement> & PopoverContent
               ref={context.arrowRef}
               context={floatingContext}
               fill={context.color === 'blue' ? theme.palette.blue[800] : theme.palette.white.main}
-              stroke={context.color === 'blue' ? theme.palette.blue[800] : theme.palette.neutral[300]}
+              stroke={context.color === 'blue' ? theme.palette.blue[800] : theme.palette.neutral[200]}
               strokeWidth={1}
               tipRadius={1}
             />


### PR DESCRIPTION
## Changed
* `PopoverContent` border color from `neutral[300]` to `neutral[200]`.

## Removed
* Background color and border radius from the Menu component, since these properties are already handled by its wrapper (usually PopoverContent).