### PR TITLE
feat: allow any helperText type for TextField

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.12",
         "@types/react": "^18.3.4",
+        "@types/react-dom": "^18.3.7",
         "@types/react-router-dom": "^5.3.3",
         "@types/rollup-plugin-peer-deps-external": "^2.2.4",
         "@types/styled-components": "^5.1.34",
@@ -6517,14 +6518,13 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/react": "*"
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-router": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.12",
     "@types/react": "^18.3.4",
+    "@types/react-dom": "^18.3.7",
     "@types/react-router-dom": "^5.3.3",
     "@types/rollup-plugin-peer-deps-external": "^2.2.4",
     "@types/styled-components": "^5.1.34",

--- a/src/components/text-field/TextField.types.ts
+++ b/src/components/text-field/TextField.types.ts
@@ -5,7 +5,7 @@ export interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   description?: string;
   endAdornment?: ReactNode;
   error?: boolean | null;
-  helperText?: string | null;
+  helperText?: ReactNode | null;
   startAdornment?: ReactNode;
   inputRef?: RefObject<HTMLInputElement>;
   inputGroupProps?: HTMLAttributes<HTMLDivElement>;


### PR DESCRIPTION
Allowing any react node type for TextField helperText prop so it can include icons.