### PR TITLE
ci: enable npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         node-version: lts/*
         cache: npm
         cache-dependency-path: '**/package-lock.json'
-        registry-url: 'https://registry.npmjs.org'
+        registry-url: https://registry.npmjs.org
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
Recently we rotated npm classic tokens due to a policy change from npmjs.com and after the rotation, the publish step is failing. 

In order to fix it, we are trying to enable [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) which enables the publish of npm packages directly from CI/CD using [OpenID Connect (OIDC)](https://openid.net/developers/how-connect-works/) authentication.